### PR TITLE
Improve ext_emconf

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,31 +1,22 @@
 <?php
-$EM_CONF[$_EXTKEY] = array(
+$EM_CONF[$_EXTKEY] = [
     'title' => 'Fluid Components',
     'description' => 'Encapsulated frontend components with Fluid\'s ViewHelper syntax',
     'category' => 'fe',
     'author' => 'Simon Praetorius',
     'author_email' => 'praetorius@sitegeist.de',
     'author_company' => 'sitegeist media solutions GmbH',
-    'shy' => '',
-    'priority' => '',
-    'module' => '',
     'state' => 'beta',
-    'internal' => '',
     'uploadfolder' => false,
-    'createDirs' => '',
-    'modify_tables' => '',
     'clearCacheOnLoad' => false,
-    'lockType' => '',
     'version' => '1.0.0',
-    'constraints' => array(
-        'depends' => array(
-            'typo3' => '8.7.0-9.9.99',
-            'fluid' => '',
-            'php' => '7.0.0-0.0.0'
-        ),
-        'conflicts' => array(
-        ),
-        'suggests' => array(
-        ),
-    )
-);
+    'constraints' => [
+        'depends' => [
+            'typo3' => '8.7.0-9.9.99'
+        ],
+        'conflicts' => [
+        ],
+        'suggests' => [
+        ],
+    ]
+];


### PR DESCRIPTION
- Use shortarray syntax
- Remove outdated keys
- Remove PHP upper limit 0.0.0
- Remove fluid as requirement as it is a dependency of TYPO3 already