### PR TITLE
[DOC] Improve component settings dependency injection

### DIFF
--- a/Documentation/Documentation.md
+++ b/Documentation/Documentation.md
@@ -189,13 +189,17 @@ class MyController
 {
     /**
      * @var \SMS\FluidComponents\Utility\ComponentSettings
-     * @inject
      */
     public $componentSettings;
 
     public function myAction()
     {
         $this->componentSettings->set('mySetting', 'myValue');
+    }
+    
+    public function injectComponentSettings(\SMS\FluidComponents\Utility\ComponentSettings $componentSettings)
+    {
+        $this->componentSettings = $componentSettings;
     }
 }
 ```


### PR DESCRIPTION
Removes the `@inject` annotation as this way should be avoided and 
should not be seen in an example of a documentation.

See https://gist.github.com/NamelessCoder/3b2e5931a6c1af19f9c3f8b46e74f837 for detailed information.