### PR TITLE
Type aliases

### DIFF
--- a/Classes/Fluid/ViewHelper/ComponentRenderer.php
+++ b/Classes/Fluid/ViewHelper/ComponentRenderer.php
@@ -407,6 +407,9 @@ class ComponentRenderer extends AbstractViewHelper
                     $param['default'] = new BooleanNode($param['default']);
                 }
 
+                // Resolve type aliases
+                $param['type'] = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['typeAliases'][$param['type']] ?? $param['type'];
+
                 $optional = $param['optional'] ?? false;
                 $description = $param['description'] ?? '';
                 $this->registerArgument($param['name'], $param['type'], $description, !$optional, $param['default']);

--- a/Documentation/DataStructures.md
+++ b/Documentation/DataStructures.md
@@ -11,8 +11,8 @@ more formal but also more flexible during integration.
 
 ## Links and Typolink
 
-`SMS\FluidComponents\Domain\Model\Link`
-`SMS\FluidComponents\Domain\Model\Typolink`
+`SMS\FluidComponents\Domain\Model\Link` (alias: `Link`)
+`SMS\FluidComponents\Domain\Model\Typolink` (alias: `Typolink`)
 
 TYPO3's backend link wizards generate a link definition in the so-called Typolink format:
 
@@ -31,7 +31,7 @@ Our sample component `Atom.Link`:
 ```xml
 <fc:component>
     <fc:param name="label" type="string" />
-    <fc:param name="link" type="SMS\FluidComponents\Domain\Model\Typolink" />
+    <fc:param name="link" type="Typolink" />
 
     <fc:renderer>
         <a href="{link.uri}" target="{link.target}" title="{link.title}" class="{link.class}">
@@ -107,7 +107,7 @@ Components should be able to accept an image as a parameter, no matter where it 
 for images that are stored in the File Abstraction Layer. However, there are cases where you want to use
 images from inside extensions or even external image urls. This is what the Image data structures offer:
 
-* `SMS\FluidComponents\Domain\Model\Image` is the base class of all image types as well as a factory
+* `SMS\FluidComponents\Domain\Model\Image` (alias: `Image`) is the base class of all image types as well as a factory
 * `SMS\FluidComponents\Domain\Model\LocalImage` wraps a local image resource, e. g. from an extension
 * `SMS\FluidComponents\Domain\Model\RemoteImage` wraps a remote image uri
 * `SMS\FluidComponents\Domain\Model\FalImage` wraps existing FAL objects, such as `File` and `FileReference`
@@ -117,7 +117,7 @@ This is how it could look like in the `Atom.Image` component:
 
 ```xml
 <fc:component>
-    <fc:param name="image" type="SMS\FluidComponents\Domain\Model\Image" />
+    <fc:param name="image" type="Image" />
     <fc:param name="width" type="integer" optional="1" />
     <fc:param name="height" type="integer" optional="1" />
 
@@ -217,5 +217,5 @@ The included data structures can also be defined with their alias. These are `Im
 To register aliases for other classes extend the typeAliases array in your `ext_localconf.php` (e.g. Phonenumber)
 
 ```php
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['typeAliases']['Phonenumber'] = VENDOR\MyExtension\Domain\Model\Phonenumber::class;
+$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['typeAliases']['Phonenumber'] = \VENDOR\MyExtension\Domain\Model\Phonenumber::class;
 ```

--- a/Documentation/DataStructures.md
+++ b/Documentation/DataStructures.md
@@ -203,3 +203,19 @@ no matter which image variant is used:
 
 In addition, the different implementations offer additional properties that can
 be used safely after checking the `type` property accordingly.
+
+## Type Aliases
+
+The included data structures can also be defined with their alias. These are `Image`, `Link` and `Typolink`.
+
+```xml
+<fc:component>
+    <fc:param name="image" type="Image" />
+</fc:component>
+```
+
+To register aliases for other classes extend the typeAliases array in your `ext_localconf.php` (e.g. Phonenumber)
+
+```php
+$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['typeAliases']['Phonenumber'] = VENDOR\MyExtension\Domain\Model\Phonenumber::class;
+```

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The following component implements a simple teaser element:
 <fc:component>
     <fc:param name="title" type="string" />
     <fc:param name="description" type="string" />
-    <fc:param name="link" type="SMS\FluidComponents\Domain\Model\Typolink" />
+    <fc:param name="link" type="Typolink" />
     <fc:param name="icon" type="string" optional="1" />
     <fc:param name="theme" type="string" optional="1">light</fc:param>
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -13,4 +13,10 @@ call_user_func(function () {
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['fluid']['namespaces']['fc'] = [];
     }
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['fluid']['namespaces']['fc'][] = 'SMS\\FluidComponents\\ViewHelpers';
+
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['typeAliases'] = [
+        'Image' => SMS\FluidComponents\Domain\Model\Image::class,
+        'Link' => SMS\FluidComponents\Domain\Model\Link::class,
+        'Typolink' => SMS\FluidComponents\Domain\Model\Typolink::class,
+    ];
 });

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -14,9 +14,10 @@ call_user_func(function () {
     }
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['fluid']['namespaces']['fc'][] = 'SMS\\FluidComponents\\ViewHelpers';
 
-    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['typeAliases'] = [
-        'Image' => SMS\FluidComponents\Domain\Model\Image::class,
-        'Link' => SMS\FluidComponents\Domain\Model\Link::class,
-        'Typolink' => SMS\FluidComponents\Domain\Model\Typolink::class,
-    ];
+    if (!isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['typeAliases'])) {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['typeAliases'] = [];
+    }
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['typeAliases']['Image'] = \SMS\FluidComponents\Domain\Model\Image::class;
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['typeAliases']['Link'] = \SMS\FluidComponents\Domain\Model\Link::class;
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['typeAliases']['Typolink'] = \SMS\FluidComponents\Domain\Model\Typolink::class;
 });


### PR DESCRIPTION
We had the idea to improve readability by defining aliases for type class names. See section in Documentation/DataStructures.md for further details.