### PR TITLE
fix #60 use cache identifier without component namespace

### DIFF
--- a/Classes/Fluid/ViewHelper/ComponentRenderer.php
+++ b/Classes/Fluid/ViewHelper/ComponentRenderer.php
@@ -447,9 +447,15 @@ class ComponentRenderer extends AbstractViewHelper
      *
      * @return string
      */
-    protected function getTemplateIdentifier(string $templateFile)
+    protected function getTemplateIdentifier(string $pathAndFilename, string $prefix = 'fluidcomponent')
     {
-        return 'fluidcomponent_' . $this->componentNamespace . '_' . sha1_file($templateFile);
+        $templateModifiedTimestamp = $pathAndFilename !== 'php://stdin' && file_exists($pathAndFilename) ? filemtime($pathAndFilename) : 0;
+        return sprintf(
+            '%s_%s_%s',
+            $prefix,
+            substr(strrchr($this->componentNamespace, "\\"), 1),
+            sha1($pathAndFilename . '|' . $templateModifiedTimestamp)
+        );
     }
 
     /**


### PR DESCRIPTION
resolves #60 

The filenames of fluid caches are much less informal e.g. `partial_Footer_All_5d1aeee0a496edc55c36d83a0c4d765e9d145713.php` so we can adopt this.

https://github.com/TYPO3/Fluid/blob/2.6/src/View/TemplatePaths.php#L626

1. Use `filemtime` instead of `sha1_file` to improve performance
2. Only use component name instead of fully qualified component name with namespace

ending up with e.g. `fluidcomponent_DocumentsNotification_e152b0e1cf3e69f344ed7a6f29b0271557d9b0a8.php`
