### PR TITLE
[task] set templatePaths from parent rendering context

### DIFF
--- a/Classes/Fluid/ViewHelper/ComponentRenderer.php
+++ b/Classes/Fluid/ViewHelper/ComponentRenderer.php
@@ -135,7 +135,9 @@ class ComponentRenderer extends AbstractViewHelper
         }
         $renderingContext->setViewHelperVariableContainer($this->renderingContext->getViewHelperVariableContainer());
         if (static::shouldUseTemplatePaths()) {
-            $renderingContext->setTemplatePaths($this->renderingContext->getTemplatePaths());
+            $renderingContext->getTemplatePaths()->setPartialRootPaths(
+                $this->renderingContext->getTemplatePaths()->getPartialRootPaths()
+            );
         }
         $variableContainer = $renderingContext->getVariableProvider();
 

--- a/Classes/Fluid/ViewHelper/ComponentRenderer.php
+++ b/Classes/Fluid/ViewHelper/ComponentRenderer.php
@@ -133,6 +133,7 @@ class ComponentRenderer extends AbstractViewHelper
             $renderingContext->setControllerContext($this->renderingContext->getControllerContext());
         }
         $renderingContext->setViewHelperVariableContainer($this->renderingContext->getViewHelperVariableContainer());
+        $renderingContext->setTemplatePaths($this->renderingContext->getTemplatePaths());
         $variableContainer = $renderingContext->getVariableProvider();
 
         // Provide information about component to renderer

--- a/Classes/Fluid/ViewHelper/ComponentRenderer.php
+++ b/Classes/Fluid/ViewHelper/ComponentRenderer.php
@@ -22,6 +22,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
+use TYPO3\CMS\Core\Configuration\Features;
 
 class ComponentRenderer extends AbstractViewHelper
 {
@@ -133,7 +134,9 @@ class ComponentRenderer extends AbstractViewHelper
             $renderingContext->setControllerContext($this->renderingContext->getControllerContext());
         }
         $renderingContext->setViewHelperVariableContainer($this->renderingContext->getViewHelperVariableContainer());
-        $renderingContext->setTemplatePaths($this->renderingContext->getTemplatePaths());
+        if (static::shouldUseTemplatePaths()) {
+            $renderingContext->setTemplatePaths($this->renderingContext->getTemplatePaths());
+        }
         $variableContainer = $renderingContext->getVariableProvider();
 
         // Provide information about component to renderer
@@ -519,5 +522,17 @@ class ComponentRenderer extends AbstractViewHelper
     protected function getComponentArgumentConverter(): ComponentArgumentConverter
     {
         return GeneralUtility::makeInstance(ComponentArgumentConverter::class);
+    }
+
+    /**
+     * @return bool
+     */
+    protected static function shouldUseTemplatePaths(): bool
+    {
+        static $assertion = null;
+        if ($assertion === null) {
+            $assertion = GeneralUtility::makeInstance(Features::class)->isFeatureEnabled('FluidComponentsTemplatePaths');
+        }
+        return $assertion;
     }
 }

--- a/Classes/Fluid/ViewHelper/ComponentRenderer.php
+++ b/Classes/Fluid/ViewHelper/ComponentRenderer.php
@@ -531,7 +531,7 @@ class ComponentRenderer extends AbstractViewHelper
     {
         static $assertion = null;
         if ($assertion === null) {
-            $assertion = GeneralUtility::makeInstance(Features::class)->isFeatureEnabled('FluidComponentsTemplatePaths');
+            $assertion = GeneralUtility::makeInstance(Features::class)->isFeatureEnabled('fluidComponents.partialsInComponents');
         }
         return $assertion;
     }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -19,4 +19,7 @@ call_user_func(function () {
     $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['typeAliases']['Typolink'] = \SMS\FluidComponents\Domain\Model\Typolink::class;
     $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['typeAliases']['Navigation'] = \SMS\FluidComponents\Domain\Model\Navigation::class;
     $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['typeAliases']['NavigationItem'] = \SMS\FluidComponents\Domain\Model\NavigationItem::class;
+    if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['FluidComponentsTemplatePaths'])) {
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['FluidComponentsTemplatePaths'] = false;
+    }
 });

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -19,7 +19,7 @@ call_user_func(function () {
     $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['typeAliases']['Typolink'] = \SMS\FluidComponents\Domain\Model\Typolink::class;
     $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['typeAliases']['Navigation'] = \SMS\FluidComponents\Domain\Model\Navigation::class;
     $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['typeAliases']['NavigationItem'] = \SMS\FluidComponents\Domain\Model\NavigationItem::class;
-    if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['FluidComponentsTemplatePaths'])) {
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['FluidComponentsTemplatePaths'] = false;
+    if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['fluidComponents.partialsInComponents'])) {
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['fluidComponents.partialsInComponents'] = false;
     }
 });


### PR DESCRIPTION
Should not hurt to add this but it enables us to use components over several channels while providing customization for specific parts by moving some chunks to actual fluid partials.