### PR TITLE
[BUGFIX] Fix notices in PHP8.1

### DIFF
--- a/Classes/Utility/ComponentSettings.php
+++ b/Classes/Utility/ComponentSettings.php
@@ -111,6 +111,7 @@ class ComponentSettings implements \TYPO3\CMS\Core\SingletonInterface, \ArrayAcc
      * @param string $offset
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->settings[$offset]);
@@ -122,6 +123,7 @@ class ComponentSettings implements \TYPO3\CMS\Core\SingletonInterface, \ArrayAcc
      * @param string $offset
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->settings[$offset];
@@ -134,6 +136,7 @@ class ComponentSettings implements \TYPO3\CMS\Core\SingletonInterface, \ArrayAcc
      * @param mixed $value
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->settings[$offset] = $value;
@@ -145,6 +148,7 @@ class ComponentSettings implements \TYPO3\CMS\Core\SingletonInterface, \ArrayAcc
      * @param string $offset
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->settings[$offset]);


### PR DESCRIPTION
Fix notices thrown in PHP8.1. because of incompatible methods.

Resolves: #98 