### PR TITLE
[BUGFIX] Make default value of component argument null when not set

### DIFF
--- a/Classes/Fluid/ViewHelper/ComponentRenderer.php
+++ b/Classes/Fluid/ViewHelper/ComponentRenderer.php
@@ -429,6 +429,7 @@ class ComponentRenderer extends AbstractViewHelper
                     $param['default'] = implode('', array_map(function ($node) use ($renderingContext) {
                         return $node->evaluate($renderingContext);
                     }, $paramNode->getChildNodes()));
+                    $param['default'] = $param['default'] === '' ? null : $param['default'];
                 }
 
                 if (in_array($param['name'], $this->reservedArguments)) {


### PR DESCRIPTION
The ComponentRenderer falls back to render
the children of <fc:param /> view helper to
obtain its default value, when a default value
is not set as VH argument, resulting in the
default being an empty string, when no children
are available (self closing tag) and no default
is explicitly set.

This comes with the downside, that it can't be
distinguished any more between a default not being
set and a default value explicitly set to an empty string
later in the rendering process.

To overcome this limitation, the default value is explicitly
set to null, when the rendered children result in an empty string.