### PR TITLE
Use `ReturnTypeWillChange` so the attribute is working as expected

### DIFF
--- a/Classes/Domain/Model/Navigation.php
+++ b/Classes/Domain/Model/Navigation.php
@@ -2,6 +2,7 @@
 
 namespace SMS\FluidComponents\Domain\Model;
 
+use ReturnTypeWillChange;
 use SMS\FluidComponents\Domain\Model\LanguageNavigationItem;
 use SMS\FluidComponents\Domain\Model\NavigationItem;
 use SMS\FluidComponents\Interfaces\ConstructibleFromArray;


### PR DESCRIPTION
I stumbled upon this bug today. In the Navigation Model the attribute is `ReturnTypeWillChange` is used, but it needed to be imported, which was missing.