### PR TITLE
[BUGFIX] initialize GLOBALS['LANG'] if missing

### DIFF
--- a/Classes/Domain/Model/Labels.php
+++ b/Classes/Domain/Model/Labels.php
@@ -129,6 +129,10 @@ class Labels implements ComponentAware, RenderingContextAware, \ArrayAccess, Con
         } else {
             $languageKey = $alternativeLanguageKeys = null;
         }
+        
+        if (!isset($GLOBALS['LANG'])) {
+            $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageServiceFactory::class)->create('default');
+        }
 
         return LocalizationUtility::translate(
             $this->generateLabelIdentifier($identifier),

--- a/Classes/Domain/Model/Labels.php
+++ b/Classes/Domain/Model/Labels.php
@@ -8,6 +8,7 @@ use SMS\FluidComponents\Interfaces\ConstructibleFromArray;
 use SMS\FluidComponents\Interfaces\ConstructibleFromNull;
 use SMS\FluidComponents\Interfaces\RenderingContextAware;
 use SMS\FluidComponents\Utility\ComponentLoader;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;

--- a/Classes/Domain/Model/Labels.php
+++ b/Classes/Domain/Model/Labels.php
@@ -130,7 +130,6 @@ class Labels implements ComponentAware, RenderingContextAware, \ArrayAccess, Con
         } else {
             $languageKey = $alternativeLanguageKeys = null;
         }
-        
         if (!isset($GLOBALS['LANG'])) {
             $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageServiceFactory::class)->create('default');
         }


### PR DESCRIPTION
PHP undefined array key is thrown if used with PHP 8.2, TYPO3 11.5 and ext:fluid_styleguide