### PR TITLE
Respect class inheritance during component argument conversion

### DIFF
--- a/Classes/Utility/ComponentArgumentConverter.php
+++ b/Classes/Utility/ComponentArgumentConverter.php
@@ -179,7 +179,7 @@ class ComponentArgumentConverter implements \TYPO3\CMS\Core\SingletonInterface
         // Check if the target type implements the constructor interface
         // required for conversion
         $conversionInfo = [];
-        if (isset($this->conversionInterfaces[$givenType]) &&
+        if (isset($this->conversionInterfaces[$givenType][0]) &&
             is_subclass_of($toType, $this->conversionInterfaces[$givenType][0])
         ) {
             $conversionInfo = $this->conversionInterfaces[$givenType];

--- a/Classes/Utility/ComponentArgumentConverter.php
+++ b/Classes/Utility/ComponentArgumentConverter.php
@@ -58,8 +58,8 @@ class ComponentArgumentConverter implements \TYPO3\CMS\Core\SingletonInterface
         ],
         FileReference::class => [
             ConstructibleFromExtbaseFile::class,
-        ]
             'fromExtbaseFile'
+        ]
     ];
 
     /**
@@ -179,15 +179,16 @@ class ComponentArgumentConverter implements \TYPO3\CMS\Core\SingletonInterface
         // Check if the target type implements the constructor interface
         // required for conversion
         $conversionInfo = [];
-        if (isset($this->conversionInterfaces[$givenType]) &&
+        if (
+            isset($this->conversionInterfaces[$givenType]) &&
             is_subclass_of($toType, $this->conversionInterfaces[$givenType][0])
         ) {
             $conversionInfo = $this->conversionInterfaces[$givenType];
         } elseif ($this->isCollectionType($toType) && $this->isAccessibleArray($givenType)) {
-            $conversionInfo = $this->conversionInterfaces['array'] ?? [];
+            $conversionInfo = $this->conversionInterfaces[$givenType];
         }
 
-        if (!$conversionInfo && class_exists($givenType)) {
+        if (!$conversionInfo) {
             $parentClasses = class_parents($givenType);
             if (is_array($parentClasses)) {
                 foreach ($parentClasses as $className) {

--- a/Classes/Utility/ComponentArgumentConverter.php
+++ b/Classes/Utility/ComponentArgumentConverter.php
@@ -179,17 +179,16 @@ class ComponentArgumentConverter implements \TYPO3\CMS\Core\SingletonInterface
         // Check if the target type implements the constructor interface
         // required for conversion
         $conversionInfo = [];
-        if (
-            isset($this->conversionInterfaces[$givenType]) &&
+        if (isset($this->conversionInterfaces[$givenType]) &&
             is_subclass_of($toType, $this->conversionInterfaces[$givenType][0])
         ) {
             $conversionInfo = $this->conversionInterfaces[$givenType];
         } elseif ($this->isCollectionType($toType) && $this->isAccessibleArray($givenType)) {
-            $conversionInfo = $this->conversionInterfaces[$givenType];
+            $conversionInfo = $this->conversionInterfaces['array'] ?? [];
         }
 
-        if (!$conversionInfo) {
-            $parentClasses = class_parents($givenType);
+        if (!$conversionInfo && class_exists($givenType)) {
+            $parentClasses = array_merge(class_parents($givenType), class_implements($givenType));
             if (is_array($parentClasses)) {
                 foreach ($parentClasses as $className) {
                     if ($this->canTypeBeConvertedToType($className, $toType)) {

--- a/Tests/Helpers/ComponentArgumentConverter/BaseObject.php
+++ b/Tests/Helpers/ComponentArgumentConverter/BaseObject.php
@@ -1,0 +1,12 @@
+<?php
+namespace SMS\FluidComponents\Tests\Helpers\ComponentArgumentConverter;
+
+class BaseObject
+{
+    public $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+}

--- a/Tests/Helpers/ComponentArgumentConverter/BaseObjectConversionInterface.php
+++ b/Tests/Helpers/ComponentArgumentConverter/BaseObjectConversionInterface.php
@@ -1,0 +1,7 @@
+<?php
+namespace SMS\FluidComponents\Tests\Helpers\ComponentArgumentConverter;
+
+interface BaseObjectConversionInterface
+{
+    public static function fromBaseObject(BaseObject $value);
+}

--- a/Tests/Helpers/ComponentArgumentConverter/DummyValue.php
+++ b/Tests/Helpers/ComponentArgumentConverter/DummyValue.php
@@ -1,7 +1,7 @@
 <?php
 namespace SMS\FluidComponents\Tests\Helpers\ComponentArgumentConverter;
 
-class DummyValue implements DummyConversionInterface
+class DummyValue implements DummyConversionInterface, BaseObjectConversionInterface
 {
     public $value;
 
@@ -13,5 +13,10 @@ class DummyValue implements DummyConversionInterface
     public static function fromString(string $value)
     {
         return new static($value);
+    }
+
+    public static function fromBaseObject(BaseObject $object)
+    {
+        return new static($object->value);
     }
 }

--- a/Tests/Helpers/ComponentArgumentConverter/SpecificObject.php
+++ b/Tests/Helpers/ComponentArgumentConverter/SpecificObject.php
@@ -1,0 +1,6 @@
+<?php
+namespace SMS\FluidComponents\Tests\Helpers\ComponentArgumentConverter;
+
+class SpecificObject extends BaseObject
+{
+}

--- a/Tests/Unit/Utility/ComponentArgumentConverterTest.php
+++ b/Tests/Unit/Utility/ComponentArgumentConverterTest.php
@@ -2,7 +2,6 @@
 
 namespace SMS\FluidComponents\Tests\Unit\Utility;
 
-use SMS\FluidComponents\Interfaces\ConstructibleFromArray;
 use SMS\FluidComponents\Tests\Helpers\ComponentArgumentConverter\BaseObject;
 use SMS\FluidComponents\Tests\Helpers\ComponentArgumentConverter\BaseObjectConversionInterface;
 use SMS\FluidComponents\Tests\Helpers\ComponentArgumentConverter\DummyConversionInterface;
@@ -67,7 +66,7 @@ class ComponentArgumentConverterTest extends \TYPO3\TestingFramework\Core\Unit\U
     public function addRemoveConversionInterface()
     {
         $this->assertEquals(
-            [],
+            false,
             $this->converter->canTypeBeConvertedToType('string', DummyValue::class)
         );
 
@@ -78,14 +77,14 @@ class ComponentArgumentConverterTest extends \TYPO3\TestingFramework\Core\Unit\U
         );
 
         $this->assertEquals(
-            [DummyConversionInterface::class, 'fromString'],
+            true,
             $this->converter->canTypeBeConvertedToType('string', DummyValue::class)
         );
 
         $this->converter->removeConversionInterface('string');
 
         $this->assertEquals(
-            [],
+            false,
             $this->converter->canTypeBeConvertedToType('string', DummyValue::class)
         );
     }
@@ -131,11 +130,11 @@ class ComponentArgumentConverterTest extends \TYPO3\TestingFramework\Core\Unit\U
 
         // Collections
         $this->assertEquals(
-            [ConstructibleFromArray::class, 'fromArray'],
+            [DummyConversionInterface::class, 'fromString'],
             $this->converter->canTypeBeConvertedToType('array', DummyValue::class . '[]')
         );
         $this->assertEquals(
-            [ConstructibleFromArray::class, 'fromArray'],
+            [DummyConversionInterface::class, 'fromString'],
             $this->converter->canTypeBeConvertedToType(\ArrayIterator::class, DummyValue::class . '[]')
         );
         $this->assertEquals(

--- a/Tests/Unit/Utility/ComponentArgumentConverterTest.php
+++ b/Tests/Unit/Utility/ComponentArgumentConverterTest.php
@@ -2,12 +2,13 @@
 
 namespace SMS\FluidComponents\Tests\Unit\Utility;
 
+use SMS\FluidComponents\Interfaces\ConstructibleFromArray;
+use SMS\FluidComponents\Utility\ComponentArgumentConverter;
 use SMS\FluidComponents\Tests\Helpers\ComponentArgumentConverter\BaseObject;
-use SMS\FluidComponents\Tests\Helpers\ComponentArgumentConverter\BaseObjectConversionInterface;
-use SMS\FluidComponents\Tests\Helpers\ComponentArgumentConverter\DummyConversionInterface;
 use SMS\FluidComponents\Tests\Helpers\ComponentArgumentConverter\DummyValue;
 use SMS\FluidComponents\Tests\Helpers\ComponentArgumentConverter\SpecificObject;
-use SMS\FluidComponents\Utility\ComponentArgumentConverter;
+use SMS\FluidComponents\Tests\Helpers\ComponentArgumentConverter\DummyConversionInterface;
+use SMS\FluidComponents\Tests\Helpers\ComponentArgumentConverter\BaseObjectConversionInterface;
 
 class ComponentArgumentConverterTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
 {
@@ -66,8 +67,9 @@ class ComponentArgumentConverterTest extends \TYPO3\TestingFramework\Core\Unit\U
     public function addRemoveConversionInterface()
     {
         $this->assertEquals(
-            false,
-            $this->converter->canTypeBeConvertedToType('string', DummyValue::class)
+            [],
+            $this->converter->canTypeBeConvertedToType('string', DummyValue::class),
+            'before conversion interface registration'
         );
 
         $this->converter->addConversionInterface(
@@ -77,15 +79,17 @@ class ComponentArgumentConverterTest extends \TYPO3\TestingFramework\Core\Unit\U
         );
 
         $this->assertEquals(
-            true,
-            $this->converter->canTypeBeConvertedToType('string', DummyValue::class)
+            [DummyConversionInterface::class, 'fromString'],
+            $this->converter->canTypeBeConvertedToType('string', DummyValue::class),
+            'after conversion interface registration'
         );
 
         $this->converter->removeConversionInterface('string');
 
         $this->assertEquals(
-            false,
-            $this->converter->canTypeBeConvertedToType('string', DummyValue::class)
+            [],
+            $this->converter->canTypeBeConvertedToType('string', DummyValue::class),
+            'after conversion interface removal'
         );
     }
 
@@ -130,11 +134,11 @@ class ComponentArgumentConverterTest extends \TYPO3\TestingFramework\Core\Unit\U
 
         // Collections
         $this->assertEquals(
-            [DummyConversionInterface::class, 'fromString'],
+            [ConstructibleFromArray::class, 'fromArray'],
             $this->converter->canTypeBeConvertedToType('array', DummyValue::class . '[]')
         );
         $this->assertEquals(
-            [DummyConversionInterface::class, 'fromString'],
+            [ConstructibleFromArray::class, 'fromArray'],
             $this->converter->canTypeBeConvertedToType(\ArrayIterator::class, DummyValue::class . '[]')
         );
         $this->assertEquals(

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,11 @@
     },
     "config": {
         "vendor-dir": ".Build/vendor",
-        "bin-dir": ".Build/bin"
+        "bin-dir": ".Build/bin",
+        "allow-plugins": {
+            "typo3/class-alias-loader": true,
+            "typo3/cms-composer-installers": true
+        }
     },
     "extra": {
         "typo3/cms": {


### PR DESCRIPTION
Currently, you have to define argument conversion behavior per input class name. That means that if you defined a conversion interface that takes a `FileInterface` as input, you need to attach this interface to `File`, `FileReference`, `ProcessedFile` in order to cover all variants.

This patch inspects the class structure of the input object and chooses the appropriate conversion automatically.