### PR TITLE
[BUGFIX] avoid type error if file do not exist

### DIFF
--- a/Classes/Domain/Model/Traits/FalFileTrait.php
+++ b/Classes/Domain/Model/Traits/FalFileTrait.php
@@ -60,6 +60,6 @@ trait FalFileTrait
 
     public function getPublicUrl(): string
     {
-        return $this->file->getPublicUrl();
+        return $this->file->getPublicUrl() ?? '';
     }
 }


### PR DESCRIPTION
if file doesn't exist on hard drive e.g. on a dev machine fluid_components throws a hard error.