### PR TITLE
Trim whitespaces in slot before counting content

### DIFF
--- a/Classes/Domain/Model/Slot.php
+++ b/Classes/Domain/Model/Slot.php
@@ -24,7 +24,7 @@ class Slot implements EscapedParameter, ConstructibleFromString, \Countable
 
     public function count(): int
     {
-        return strlen($this->html);
+        return strlen(trim($this->html));
     }
 
     public function __toString(): string


### PR DESCRIPTION
The slot model implements the Countable interface that is used when evaluating the variable in an if condition. Before counting the content by calling strlen it should be trimmed so whitespaces, that are common in HTML, are ignored.

Example
```
...
<fc:content name="foo">

</fc:content>
...
```

Checking the Slot "foo" in a condition should be false as the slot does not contain real content.

`<f:if condition="{foo}">this should not be shown</f:if>`