### PR TITLE
[BUGFIX] pass the original request 

### DIFF
--- a/Classes/Fluid/ViewHelper/ComponentRenderer.php
+++ b/Classes/Fluid/ViewHelper/ComponentRenderer.php
@@ -175,6 +175,11 @@ class ComponentRenderer extends AbstractViewHelper
         $renderingContext = $this->getRenderingContext();
         if ((new Typo3Version())->getMajorVersion() < 12 && $this->renderingContext->getControllerContext()) {
             $renderingContext->setControllerContext($this->renderingContext->getControllerContext());
+        } else {
+            // set the original request to preserve the request attributes
+            // some ViewHelpers expect a ServerRequestInterface or other attributes inside the request
+            // e.g. f:uri.action, f:page.action
+            $renderingContext->setRequest($this->renderingContext->getRequest());
         }
         $renderingContext->setViewHelperVariableContainer($this->renderingContext->getViewHelperVariableContainer());
         if (static::shouldUseTemplatePaths()) {


### PR DESCRIPTION
in the ComponentRenderer to the RenderingContext to preserve request attributes used by various ViewHelpers