### PR TITLE
[BUGFIX] Don't lowercase component tag names in XSD

### DIFF
--- a/Classes/Service/XsdGenerator.php
+++ b/Classes/Service/XsdGenerator.php
@@ -82,7 +82,7 @@ class XsdGenerator
         $tagName = '';
         if (strpos($componentName, $nameSpace) === 0) {
             $tagNameWithoutNameSpace = substr($componentName, strlen($nameSpace) + 1);
-            $tagName = strtolower(str_replace('\\', '.', $tagNameWithoutNameSpace));
+            $tagName = lcfirst(str_replace('\\', '.', $tagNameWithoutNameSpace));
         }
         return $tagName;
     }


### PR DESCRIPTION
Component names are case sensitive,
because a file path is derived from it,
similar to class names of view helpers,
where the autoloader derives the file name
from the class name.

Therefore only the first char must be lowercased
not the whole tag name when generating the XSD