### PR TITLE
[FEATURE] Add float type support for component params

### DIFF
--- a/Classes/Domain/Model/FloatType.php
+++ b/Classes/Domain/Model/FloatType.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SMS\FluidComponents\Domain\Model;
+
+use SMS\FluidComponents\Interfaces\ConstructibleFromFloat;
+use SMS\FluidComponents\Interfaces\ConstructibleFromInteger;
+use SMS\FluidComponents\Interfaces\ConstructibleFromString;
+
+class FloatType implements ConstructibleFromString, ConstructibleFromInteger, ConstructibleFromFloat
+{
+    public static function fromString(string $value): float
+    {
+        return (float)$value;
+    }
+
+    public static function fromInteger(int $value): float
+    {
+        return (float)$value;
+    }
+
+    public static function fromFloat(float $value): float
+    {
+        return $value;
+    }
+}

--- a/Classes/Interfaces/ConstructibleFromFloat.php
+++ b/Classes/Interfaces/ConstructibleFromFloat.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace SMS\FluidComponents\Interfaces;
+
+/**
+ * ConstructibleFromFloat defines an alternative constructor
+ * which "converts" the provided float to the class implementing
+ * the interface.
+ *
+ * The reason for this is because of php gettype() returning the string 'double' for float values for historical reasons
+ */
+interface ConstructibleFromFloat
+{
+    /**
+     * Creates an instance of the class based on the provided integer
+     *
+     * @param float $value
+     * @return object
+     */
+    public static function fromFloat(float $value);
+}

--- a/Classes/Utility/ComponentArgumentConverter.php
+++ b/Classes/Utility/ComponentArgumentConverter.php
@@ -8,6 +8,7 @@ use SMS\FluidComponents\Interfaces\ConstructibleFromDateTime;
 use SMS\FluidComponents\Interfaces\ConstructibleFromDateTimeImmutable;
 use SMS\FluidComponents\Interfaces\ConstructibleFromExtbaseFile;
 use SMS\FluidComponents\Interfaces\ConstructibleFromFileInterface;
+use SMS\FluidComponents\Interfaces\ConstructibleFromFloat;
 use SMS\FluidComponents\Interfaces\ConstructibleFromInteger;
 use SMS\FluidComponents\Interfaces\ConstructibleFromNull;
 use SMS\FluidComponents\Interfaces\ConstructibleFromString;
@@ -31,6 +32,10 @@ class ComponentArgumentConverter implements \TYPO3\CMS\Core\SingletonInterface
         'integer' => [
             ConstructibleFromInteger::class,
             'fromInteger'
+        ],
+        'double' => [
+            ConstructibleFromFloat::class,
+            'fromFloat'
         ],
         'array' => [
             ConstructibleFromArray::class,

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -19,6 +19,7 @@ call_user_func(function () {
     $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['typeAliases']['NavigationItem'] = \SMS\FluidComponents\Domain\Model\NavigationItem::class;
     $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['typeAliases']['Labels'] = \SMS\FluidComponents\Domain\Model\Labels::class;
     $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['typeAliases']['Slot'] = \SMS\FluidComponents\Domain\Model\Slot::class;
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['typeAliases']['float'] = \SMS\FluidComponents\Domain\Model\FloatType::class;
 
     if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['fluidComponents.partialsInComponents'])) {
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['fluidComponents.partialsInComponents'] = false;


### PR DESCRIPTION
Summary:
fluid-components internally uses phps `gettype()` method to check the actual type of a passed component param value. `gettype()` however returns the string 'double' for floating numbers because of historical reasons (see the [php manual](https://www.php.net/manual/en/function.gettype.php) for reference).
This causes the issue of passed floating numbers to components which have a declared param type of "float" to raise an `InvalidArgumentException` which this pr shall fix.