### PR TITLE
Do not fetch ContentViewhelper nodes recursively

### DIFF
--- a/Classes/Fluid/ViewHelper/ComponentRenderer.php
+++ b/Classes/Fluid/ViewHelper/ComponentRenderer.php
@@ -551,7 +551,7 @@ class ComponentRenderer extends AbstractViewHelper
     protected function extractContentViewHelpers(NodeInterface $node, RenderingContext $renderingContext): array
     {
         return array_reduce(
-            $this->extractViewHelpers($node, ContentViewHelper::class),
+            $this->extractViewHelpers($node, ContentViewHelper::class, false),
             function (array $nodes, ViewHelperNode $node) use ($renderingContext) {
                 $slotArgument = $node->getArguments()['slot'] ?? null;
                 $slotName = ($slotArgument) ? $slotArgument->evaluate($renderingContext) : self::DEFAULT_SLOT;
@@ -569,7 +569,7 @@ class ComponentRenderer extends AbstractViewHelper
      * @param string $viewHelperClassName
      * @return array
      */
-    protected function extractViewHelpers(NodeInterface $node, string $viewHelperClassName): array
+    protected function extractViewHelpers(NodeInterface $node, string $viewHelperClassName, bool $recursive = true): array
     {
         $viewHelperNodes = [];
 
@@ -579,7 +579,7 @@ class ComponentRenderer extends AbstractViewHelper
 
         if ($node instanceof ViewHelperNode && $node->getViewHelperClassName() === $viewHelperClassName) {
             $viewHelperNodes[] = $node;
-        } else {
+        } elseif ($recursive) {
             foreach ($node->getChildNodes() as $childNode) {
                 $viewHelperNodes = array_merge(
                     $viewHelperNodes,


### PR DESCRIPTION
Content ViewHelpers should only be fetched as direct children, not recursively. Fetching them recursively in templates will not work if components are nested, as slots of the inner component would also be applied to the outer component. Placing content in an if-else block, thus defining the content twice, will also not work and would no longer be possible with this change, which should prevent some headaches.