### PR TITLE
TYPO3 13 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   terUpload:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: tomasnorre/typo3-upload-ter@v2
         with:
           api-token: ${{ secrets.TYPO3_API_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,14 +40,8 @@ jobs:
         strategy:
             max-parallel: 2
             matrix:
-                php-versions: ['8.2', '8.1', '8.0']
-                typo3-versions: [12, 11]
-                exclude:
-                    - php-versions: '8.0'
-                      typo3-versions: 12
-                include:
-                    - php-versions: '7.4'
-                      typo3-versions: 11
+                php-versions: ['8.3', '8.2']
+                typo3-versions: [13, 12]
 
         name: Unit (PHP ${{ matrix.php-versions }}, TYPO3 ${{ matrix.typo3-versions }})
         steps:
@@ -80,14 +74,8 @@ jobs:
         strategy:
             max-parallel: 2
             matrix:
-                php-versions: ['8.2', '8.1', '8.0']
-                typo3-versions: [12, 11]
-                exclude:
-                    - php-versions: '8.0'
-                      typo3-versions: 12
-                include:
-                    - php-versions: '7.4'
-                      typo3-versions: 11
+                php-versions: ['8.3', '8.2']
+                typo3-versions: [13, 12]
 
         name: Functional (PHP ${{ matrix.php-versions }}, TYPO3 ${{ matrix.typo3-versions }})
         steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,17 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
+
+            -
+                name: Set up Docker Compose
+                run: |
+                    docker-compose --version || {
+                    echo "Docker Compose not found, installing..."
+                    sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+                    sudo chmod +x /usr/local/bin/docker-compose
+                    docker-compose --version
+                    }
 
             -
                 name: Validate composer.json
@@ -16,7 +26,7 @@ jobs:
 
             -
                 name: Cache composer dependencies
-                uses: actions/cache@v3
+                uses: actions/cache@v4
                 with:
                     path: ~/.composer/cache
                     key: composer
@@ -46,7 +56,17 @@ jobs:
         name: Unit (PHP ${{ matrix.php-versions }}, TYPO3 ${{ matrix.typo3-versions }})
         steps:
             -
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
+
+            -
+                name: Set up Docker Compose
+                run: |
+                    docker-compose --version || {
+                    echo "Docker Compose not found, installing..."
+                    sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+                    sudo chmod +x /usr/local/bin/docker-compose
+                    docker-compose --version
+                    }
 
             -
                 name: Validate composer.json
@@ -54,7 +74,7 @@ jobs:
 
             -
                 name: Cache composer dependencies
-                uses: actions/cache@v3
+                uses: actions/cache@v4
                 with:
                     path: ~/.composer/cache
                     key: php-${{ matrix.php-versions }}-typo3-${{ matrix.typo3-versions }}
@@ -80,7 +100,17 @@ jobs:
         name: Functional (PHP ${{ matrix.php-versions }}, TYPO3 ${{ matrix.typo3-versions }})
         steps:
             -
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
+
+            -
+                name: Set up Docker Compose
+                run: |
+                    docker-compose --version || {
+                    echo "Docker Compose not found, installing..."
+                    sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+                    sudo chmod +x /usr/local/bin/docker-compose
+                    docker-compose --version
+                    }
 
             -
                 name: Validate composer.json
@@ -88,7 +118,7 @@ jobs:
 
             -
                 name: Cache composer dependencies
-                uses: actions/cache@v3
+                uses: actions/cache@v4
                 with:
                     path: ~/.composer/cache
                     key: php-${{ matrix.php-versions }}-typo3-${{ matrix.typo3-versions }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .Build
 composer.lock
 /var
-/Build/.phpunit.result.cache
+/Build/Testing/.phpunit.result.cache
+/Build/Testing/.phpunit.cache/
 /Build/testing-docker/.env

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -61,17 +61,15 @@ Options:
             - postgres: use postgres
             - sqlite: use sqlite
 
-    -p <7.4|8.0|8.1|8.2>
+    -p <8.2|8.3>
         Specifies the PHP minor version to be used
-            - 7.4 (default): use PHP 7.4
-            - 8.0: use PHP 8.0
-            - 8.1: use PHP 8.1
-            - 8.2: use PHP 8.2
+            - 8.2 (default): use PHP 8.2
+            - 8.3: use PHP 8.3
 
-    -t <11|12>
+    -t <12|13>
         Specifies the TYPO3 version to be used
-            - 11 (default): use TYPO3 11
-            - 12: use TYPO3 12
+            - 12 (default): use TYPO3 12
+            - 13: use TYPO3 13
 
     -e "<phpunit options>"
         Only with -s functional|unit
@@ -103,11 +101,11 @@ Options:
         Show this help.
 
 Examples:
-    # Run unit tests using PHP 7.4
+    # Run unit tests using PHP 8.2 and TYPO3 12
     ./Build/Scripts/runTests.sh
 
-    # Run unit tests using PHP 7.3
-    ./Build/Scripts/runTests.sh -p 7.3
+    # Run unit tests using PHP 8.3 and TYPO3 13
+    ./Build/Scripts/runTests.sh -p 8.3 -t 13
 EOF
 
 # Test if docker-compose exists, else exit out with error
@@ -133,8 +131,8 @@ else
 fi
 TEST_SUITE="unit"
 DBMS="mariadb"
-PHP_VERSION="7.4"
-TYPO3_VERSION="11"
+PHP_VERSION="8.2"
+TYPO3_VERSION="12"
 PHP_XDEBUG_ON=0
 PHP_XDEBUG_PORT=9003
 EXTRA_TEST_OPTIONS=""

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -108,9 +108,9 @@ Examples:
     ./Build/Scripts/runTests.sh -p 8.3 -t 13
 EOF
 
-# Test if docker-compose exists, else exit out with error
-if ! type "docker-compose" > /dev/null; then
-    echo "This script relies on docker and docker-compose. Please install" >&2
+# Test if docker exists, else exit out with error
+if ! type "docker" > /dev/null; then
+    echo "This script relies on docker and docker. Please install" >&2
     exit 1
 fi
 
@@ -214,41 +214,41 @@ fi
 case ${TEST_SUITE} in
     composerInstall)
         setUpDockerComposeDotEnv
-        docker-compose run composer_install
+        docker compose run composer_install
         SUITE_EXIT_CODE=$?
-        docker-compose down
+        docker compose down
         ;;
     composerInstallMax)
         setUpDockerComposeDotEnv
-        docker-compose run composer_install_max
+        docker compose run composer_install_max
         SUITE_EXIT_CODE=$?
-        docker-compose down
+        docker compose down
         ;;
     composerInstallMin)
         setUpDockerComposeDotEnv
-        docker-compose run composer_install_min
+        docker compose run composer_install_min
         SUITE_EXIT_CODE=$?
-        docker-compose down
+        docker compose down
         ;;
     composerValidate)
         setUpDockerComposeDotEnv
-        docker-compose run composer_validate
+        docker compose run composer_validate
         SUITE_EXIT_CODE=$?
-        docker-compose down
+        docker compose down
         ;;
     functional)
         setUpDockerComposeDotEnv
         case ${DBMS} in
             mariadb)
-                docker-compose run functional_mariadb10
+                docker compose run functional_mariadb10
                 SUITE_EXIT_CODE=$?
                 ;;
             mssql)
-                docker-compose run functional_mssql2019latest
+                docker compose run functional_mssql2019latest
                 SUITE_EXIT_CODE=$?
                 ;;
             postgres)
-                docker-compose run functional_postgres10
+                docker compose run functional_postgres10
                 SUITE_EXIT_CODE=$?
                 ;;
             sqlite)
@@ -257,7 +257,7 @@ case ${TEST_SUITE} in
                 # root if docker creates it. Thank you, docker. We create the path beforehand
                 # to avoid permission issues.
                 mkdir -p ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/
-                docker-compose run functional_sqlite
+                docker compose run functional_sqlite
                 SUITE_EXIT_CODE=$?
                 ;;
             *)
@@ -266,25 +266,25 @@ case ${TEST_SUITE} in
                 echo "${HELP}" >&2
                 exit 1
         esac
-        docker-compose down
+        docker compose down
         ;;
     lintPhp)
         setUpDockerComposeDotEnv
-        docker-compose run lint_php
+        docker compose run lint_php
         SUITE_EXIT_CODE=$?
-        docker-compose down
+        docker compose down
         ;;
     lintEditorconfig)
             setUpDockerComposeDotEnv
-            docker-compose run lint_editorconfig
+            docker compose run lint_editorconfig
             SUITE_EXIT_CODE=$?
-            docker-compose down
+            docker compose down
             ;;
     unit)
         setUpDockerComposeDotEnv
-        docker-compose run unit
+        docker compose run unit
         SUITE_EXIT_CODE=$?
-        docker-compose down
+        docker compose down
         ;;
     update)
         # pull typo3/core-testing-*:latest versions of those ones that exist locally

--- a/Build/Testing/FunctionalTests.xml
+++ b/Build/Testing/FunctionalTests.xml
@@ -1,28 +1,27 @@
+<?xml version="1.0"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.2/phpunit.xsd"
     backupGlobals="true"
     bootstrap="FunctionalTestsBootstrap.php"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertWarningsToExceptions="true"
-    forceCoversAnnotation="false"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"
     stopOnSkipped="false"
-    verbose="false"
     beStrictAboutTestsThatDoNotTestAnything="false"
     failOnWarning="true"
+    cacheDirectory=".phpunit.cache"
+    requireCoverageMetadata="false"
 >
-    <testsuites>
-        <testsuite name="Functional tests">
-            <directory>../../Tests/Functional/</directory>
-        </testsuite>
-    </testsuites>
-    <php>
-        <const name="TYPO3_MODE" value="BE" />
-        <ini name="display_errors" value="1" />
-        <env name="TYPO3_CONTEXT" value="Testing" />
-    </php>
+<testsuites>
+    <testsuite name="Functional tests">
+        <directory>../../Tests/Functional/</directory>
+    </testsuite>
+</testsuites>
+<php>
+    <const name="TYPO3_MODE" value="BE"/>
+    <ini name="display_errors" value="1"/>
+    <env name="TYPO3_CONTEXT" value="Testing"/>
+</php>
 </phpunit>

--- a/Build/Testing/UnitTests.xml
+++ b/Build/Testing/UnitTests.xml
@@ -1,30 +1,28 @@
+<?xml version="1.0"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.2/phpunit.xsd"
     backupGlobals="true"
     bootstrap="UnitTestsBootstrap.php"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertWarningsToExceptions="true"
-    convertNoticesToExceptions="true"
-    forceCoversAnnotation="false"
     processIsolation="false"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"
     stopOnSkipped="false"
-    verbose="false"
     beStrictAboutTestsThatDoNotTestAnything="false"
     failOnWarning="true"
+    cacheDirectory=".phpunit.cache"
+    requireCoverageMetadata="false"
 >
-    <testsuites>
-        <testsuite name="Unit tests">
-            <directory>../../Tests/Unit/</directory>
-        </testsuite>
-    </testsuites>
-    <php>
-        <const name="TYPO3_MODE" value="BE" />
-        <ini name="display_errors" value="1" />
-        <env name="TYPO3_CONTEXT" value="Testing" />
-    </php>
+<testsuites>
+    <testsuite name="Unit tests">
+        <directory>../../Tests/Unit/</directory>
+    </testsuite>
+</testsuites>
+<php>
+    <const name="TYPO3_MODE" value="BE"/>
+    <ini name="display_errors" value="1"/>
+    <env name="TYPO3_CONTEXT" value="Testing"/>
+</php>
 </phpunit>

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 services:
     mariadb10:
         image: mariadb:10

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -301,7 +301,7 @@ services:
                 php -v | grep '^PHP';
                 echo -n 'ec version: ';
                 .Build/bin/ec -version;
-                .Build/bin/ec -exclude .phpunit.result.cache .
+                .Build/bin/ec -exclude .phpunit.*  .
             "
 
     unit:

--- a/Classes/Command/GenerateXsdCommand.php
+++ b/Classes/Command/GenerateXsdCommand.php
@@ -11,7 +11,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class GenerateXsdCommand extends Command
 {
-    private XsdGenerator $xsdGenerator;
+    public function __construct(private XsdGenerator $xsdGenerator)
+    {
+        parent::__construct();
+    }
 
     protected function configure()
     {
@@ -45,7 +48,7 @@ EOH
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $path = $input->getArgument('path');
-        if (substr($path, 0, 1) !== DIRECTORY_SEPARATOR) {
+        if (substr((string) $path, 0, 1) !== DIRECTORY_SEPARATOR) {
             $path = realpath(getcwd() . DIRECTORY_SEPARATOR . $path);
         }
         if ($output->isVerbose()) {
@@ -74,10 +77,5 @@ EOH
             }
             return 0;
         }
-    }
-
-    public function injectXsdGenerator(XsdGenerator $xsdGenerator): void
-    {
-        $this->xsdGenerator = $xsdGenerator;
     }
 }

--- a/Classes/Domain/Model/DateTime.php
+++ b/Classes/Domain/Model/DateTime.php
@@ -13,11 +13,9 @@ class DateTime extends \DateTime implements ConstructibleFromString, Constructib
     /**
      * Convert string input to datetime object
      *
-     * @param string $value
-     * @return DateTime|false
      * @throws Exception
      */
-    public static function fromString(string $value)
+    public static function fromString(string $value): object
     {
         return new static($value);
     }
@@ -25,8 +23,6 @@ class DateTime extends \DateTime implements ConstructibleFromString, Constructib
     /**
      * Convert UNIX timestamp to datetime object
      *
-     * @param int $value
-     * @return self
      * @throws Exception
      */
     public static function fromInteger(int $value): self
@@ -37,8 +33,6 @@ class DateTime extends \DateTime implements ConstructibleFromString, Constructib
     /**
      * Passes datetime object
      *
-     * @param \DateTime $value
-     * @return static
      * @throws Exception
      */
     public static function fromDateTime(\DateTime $value): self
@@ -49,8 +43,6 @@ class DateTime extends \DateTime implements ConstructibleFromString, Constructib
     /**
      * Passes immutable datetime object
      *
-     * @param \DateTimeImmutable $value
-     * @return static
      * @throws Exception
      */
     public static function fromDateTimeImmutable(\DateTimeImmutable $value): self

--- a/Classes/Domain/Model/FalFile.php
+++ b/Classes/Domain/Model/FalFile.php
@@ -13,8 +13,6 @@ class FalFile extends File
 
     /**
      * Type of file to differentiate implementations in Fluid templates
-     *
-     * @var string
      */
-    protected $type = 'FalFile';
+    protected string $type = 'FalFile';
 }

--- a/Classes/Domain/Model/FalImage.php
+++ b/Classes/Domain/Model/FalImage.php
@@ -13,10 +13,8 @@ class FalImage extends Image
 
     /**
      * Type of image to differentiate implementations in Fluid templates
-     *
-     * @var string
      */
-    protected $type = 'FalImage';
+    protected string $type = 'FalImage';
 
 
     public function getAlternative(): ?string

--- a/Classes/Domain/Model/File.php
+++ b/Classes/Domain/Model/File.php
@@ -38,17 +38,17 @@ abstract class File implements
     /**
      * Title of the file
      */
-    protected ?string $title;
+    protected ?string $title = null;
 
     /**
      * Description of the file
      */
-    protected ?string $description;
+    protected ?string $description = null;
 
     /**
      * Properties of the file
      */
-    protected ?array $properties;
+    protected ?array $properties = null;
 
     /**
      * Should return the public URL of the file to be used in an img tag
@@ -130,7 +130,7 @@ abstract class File implements
      *
      * @throws InvalidArgumentException|FileReferenceNotFoundException
      */
-    public static function fromArray(array $value): self
+    public static function fromArray(array $value): ?self
     {
         // Create an imafe from an existing FAL object
         if (isset($value['fileObject'])) {
@@ -287,7 +287,7 @@ abstract class File implements
      *
      * @see \TYPO3\CMS\Fluid\ViewHelpers\Uri\ResourceViewHelper
      */
-    public static function fromExtensionResource(string $extensionKey, string $path): self
+    public static function fromExtensionResource(string $extensionKey, string $path): ?self
     {
         return static::fromString('EXT:' . $extensionKey . '/Resources/Public/' . $path);
     }

--- a/Classes/Domain/Model/File.php
+++ b/Classes/Domain/Model/File.php
@@ -32,44 +32,31 @@ abstract class File implements
 {
     /**
      * Type of file to differentiate implementations in Fluid templates
-     *
-     * @var string
      */
-    protected $type = 'File';
+    protected string $type = 'File';
 
     /**
      * Title of the file
-     *
-     * @var string|null
      */
-    protected $title;
+    protected ?string $title;
 
     /**
      * Description of the file
-     *
-     * @var string|null
      */
-    protected $description;
+    protected ?string $description;
 
     /**
      * Properties of the file
-     *
-     * @var array|null
      */
-    protected $properties;
+    protected ?array $properties;
 
     /**
      * Should return the public URL of the file to be used in an img tag
-     *
-     * @return string
      */
     abstract public function getPublicUrl(): string;
 
     /**
      * Creates a file object based on a static file (local or remote)
-     *
-     * @param string $value
-     * @return self
      */
     public static function fromString(string $value): ?self
     {
@@ -79,7 +66,7 @@ abstract class File implements
 
         try {
             return new RemoteFile($value);
-        } catch (InvalidRemoteFileException $e) {
+        } catch (InvalidRemoteFileException) {
             $file = GeneralUtility::makeInstance(ResourceFactory::class)->retrieveFileOrFolderObject($value);
             return ($file) ? new FalFile($file) : null;
         }
@@ -87,9 +74,6 @@ abstract class File implements
 
     /**
      * Creates a file object based on a FAL file uid
-     *
-     * @param integer $value
-     * @return self
      */
     public static function fromInteger(int $value): self
     {
@@ -144,9 +128,6 @@ abstract class File implements
      *
      *     [ "file" => "https://example.com/MyFile.txt" ]
      *
-     *
-     * @param array $value
-     * @return self
      * @throws InvalidArgumentException|FileReferenceNotFoundException
      */
     public static function fromArray(array $value): self
@@ -232,9 +213,6 @@ abstract class File implements
 
     /**
      * Creates a file object as a wrapper around an existing FAL object
-     *
-     * @param FileInterface $value
-     * @return self
      */
     public static function fromFileInterface(FileInterface $value): self
     {
@@ -248,9 +226,6 @@ abstract class File implements
 
     /**
      * Creates a file object based on a FAL file uid
-     *
-     * @param integer $fileUid
-     * @return self
      */
     public static function fromFileUid(int $fileUid): self
     {
@@ -261,9 +236,6 @@ abstract class File implements
 
     /**
      * Creates a file object based on a FAL file reference uid
-     *
-     * @param integer $fileReferenceUid
-     * @return self
      */
     public static function fromFileReferenceUid(int $fileReferenceUid): self
     {
@@ -277,8 +249,8 @@ abstract class File implements
      *
      * @param string $tableName  database table where the file is referenced
      * @param string $fieldName  database field name in which the file is referenced
-     * @param integer $uid       uid of the database record in which the file is referenced
-     * @param integer $counter   zero-based index of the file reference to use
+     * @param int $uid       uid of the database record in which the file is referenced
+     * @param int $counter   zero-based index of the file reference to use
      *                           (in case there are multiple)
      * @return self
      * @throws FileReferenceNotFoundException
@@ -313,9 +285,6 @@ abstract class File implements
      * Creates a file object based on a static resource in an extension
      * (Resources/Public/...)
      *
-     * @param string $extensionKey
-     * @param string $path
-     * @return self
      * @see \TYPO3\CMS\Fluid\ViewHelpers\Uri\ResourceViewHelper
      */
     public static function fromExtensionResource(string $extensionKey, string $path): self
@@ -363,8 +332,6 @@ abstract class File implements
 
     /**
      * Use public url of file as string representation of file objects
-     *
-     * @return string
      */
     public function __toString(): string
     {

--- a/Classes/Domain/Model/Image.php
+++ b/Classes/Domain/Model/Image.php
@@ -26,12 +26,12 @@ abstract class Image extends File
     /**
      * Alternative text for the image
      */
-    protected ?string $alternative;
+    protected ?string $alternative = null;
 
     /**
      * Copyright of the image
      */
-    protected ?string $copyright;
+    protected ?string $copyright = null;
 
     /**
      * Creates an image object based on a static file (local or remote)
@@ -112,7 +112,7 @@ abstract class Image extends File
      *
      * @throws InvalidArgumentException|FileReferenceNotFoundException
      */
-    public static function fromArray(array $value): self
+    public static function fromArray(array $value): ?self
     {
         try {
             /** @var Image */

--- a/Classes/Domain/Model/Image.php
+++ b/Classes/Domain/Model/Image.php
@@ -20,30 +20,21 @@ abstract class Image extends File
 {
     /**
      * Type of image to differentiate implementations in Fluid templates
-     *
-     * @var string
      */
-    protected $type = 'Image';
+    protected string $type = 'Image';
 
     /**
      * Alternative text for the image
-     *
-     * @var string|null
      */
-    protected $alternative;
+    protected ?string $alternative;
 
     /**
      * Copyright of the image
-     *
-     * @var string|null
      */
-    protected $copyright;
+    protected ?string $copyright;
 
     /**
      * Creates an image object based on a static file (local or remote)
-     *
-     * @param string $value
-     * @return self
      */
     public static function fromString(string $value): ?self
     {
@@ -53,7 +44,7 @@ abstract class Image extends File
 
         try {
             return new RemoteImage($value);
-        } catch (InvalidRemoteImageException $e) {
+        } catch (InvalidRemoteImageException) {
             $file = GeneralUtility::makeInstance(ResourceFactory::class)->retrieveFileOrFolderObject($value);
             return ($file) ? new FalImage($file) : null;
         }
@@ -119,8 +110,6 @@ abstract class Image extends File
      *         "alternative" => "My Alternative Text"
      *     ]
      *
-     * @param array $value
-     * @return self
      * @throws InvalidArgumentException|FileReferenceNotFoundException
      */
     public static function fromArray(array $value): self
@@ -165,9 +154,6 @@ abstract class Image extends File
 
     /**
      * Creates a file object as a wrapper around an existing FAL object
-     *
-     * @param FileInterface $value
-     * @return self
      */
     public static function fromFileInterface(FileInterface $value): self
     {
@@ -176,10 +162,6 @@ abstract class Image extends File
 
     /**
      * Creates a placeholder image based on the provided image dimensions
-     *
-     * @param integer $width
-     * @param integer $height
-     * @return self
      */
     public static function fromDimensions(int $width, int $height): self
     {

--- a/Classes/Domain/Model/Labels.php
+++ b/Classes/Domain/Model/Labels.php
@@ -8,6 +8,7 @@ use SMS\FluidComponents\Interfaces\ConstructibleFromArray;
 use SMS\FluidComponents\Interfaces\ConstructibleFromNull;
 use SMS\FluidComponents\Interfaces\RenderingContextAware;
 use SMS\FluidComponents\Utility\ComponentLoader;
+use TYPO3\CMS\Core\Localization\Locales;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
@@ -35,7 +36,7 @@ class Labels implements ComponentAware, RenderingContextAware, \ArrayAccess, Con
     /**
      * Cache for component labels file
      */
-    protected string $labelsFile;
+    protected string $labelsFile = '';
 
     public function __construct(array $overrideLabels = [])
     {
@@ -96,16 +97,16 @@ class Labels implements ComponentAware, RenderingContextAware, \ArrayAccess, Con
         if ($viewHelperVariableContainer->exists(ComponentRenderer::class, self::OVERRIDE_LANGUAGE_KEY)) {
             $languageKey = $viewHelperVariableContainer->get(ComponentRenderer::class, self::OVERRIDE_LANGUAGE_KEY);
             $alternativeLanguageKeys = $viewHelperVariableContainer->get(ComponentRenderer::class, self::OVERRIDE_LANGUAGE_ALTERNATIVES);
-        } else {
-            $languageKey = $alternativeLanguageKeys = null;
+
+            $localeFactory = GeneralUtility::makeInstance(Locales::class);
+            $locale = $localeFactory->createLocale($languageKey, $alternativeLanguageKeys);
         }
 
         return LocalizationUtility::translate(
             $this->generateLabelIdentifier($identifier),
             null,
             null,
-            $languageKey,
-            $alternativeLanguageKeys
+            $locale ?? null
         );
     }
 

--- a/Classes/Domain/Model/Labels.php
+++ b/Classes/Domain/Model/Labels.php
@@ -14,42 +14,29 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 class Labels implements ComponentAware, RenderingContextAware, \ArrayAccess, ConstructibleFromArray, ConstructibleFromNull
 {
-    const OVERRIDE_LANGUAGE_KEY = 'languageKey';
-    const OVERRIDE_LANGUAGE_ALTERNATIVES = 'alternativeLanguageKeys';
+    public const OVERRIDE_LANGUAGE_KEY = 'languageKey';
+    public const OVERRIDE_LANGUAGE_ALTERNATIVES = 'alternativeLanguageKeys';
 
     /**
      * Namespace of the current component
-     *
-     * @var string
      */
-    protected $componentNamespace;
+    protected string $componentNamespace;
 
     /**
      * Fluid rendering context
-     *
-     * @var RenderingContextInterface
      */
-    protected $renderingContext;
+    protected RenderingContextInterface $renderingContext;
 
     /**
      * Static label values that should override those defined in language files
-     *
-     * @var array
      */
-    protected $overrideLabels = [];
+    protected array $overrideLabels = [];
 
     /**
      * Cache for component labels file
-     *
-     * @var string
      */
-    protected $labelsFile;
+    protected string $labelsFile;
 
-    /**
-     * Constructor
-     *
-     * @param array $overrideLabels
-     */
     public function __construct(array $overrideLabels = [])
     {
         $this->overrideLabels = $overrideLabels;
@@ -57,9 +44,6 @@ class Labels implements ComponentAware, RenderingContextAware, \ArrayAccess, Con
 
     /**
      * Generate object based on an array passed to the component
-     *
-     * @param array $overrideLabels
-     * @return self
      */
     public static function fromArray(array $overrideLabels): self
     {
@@ -68,8 +52,6 @@ class Labels implements ComponentAware, RenderingContextAware, \ArrayAccess, Con
 
     /**
      * Generate object, even if component parameter is optional and omitted
-     *
-     * @return self
      */
     public static function fromNull(): self
     {
@@ -78,9 +60,6 @@ class Labels implements ComponentAware, RenderingContextAware, \ArrayAccess, Con
 
     /**
      * Receive component context to determine language file path
-     *
-     * @param string $componentNamespace
-     * @return void
      */
     public function setComponentNamespace(string $componentNamespace): void
     {
@@ -89,9 +68,6 @@ class Labels implements ComponentAware, RenderingContextAware, \ArrayAccess, Con
 
     /**
      * Receive current fluid rendering context
-     *
-     * @param RenderingContextInterface $renderingContext
-     * @return void
      */
     public function setRenderingContext(RenderingContextInterface $renderingContext): void
     {
@@ -100,22 +76,16 @@ class Labels implements ComponentAware, RenderingContextAware, \ArrayAccess, Con
 
     /**
      * Check if language label is defined
-     *
-     * @param mixed $identifier
-     * @return boolean
      */
-    public function offsetExists($identifier): bool
+    public function offsetExists(mixed $identifier): bool
     {
         return $this->offsetGet($identifier) !== null;
     }
 
     /**
      * Return value of language label
-     *
-     * @param mixed $identifier
-     * @return string|null
      */
-    public function offsetGet($identifier): ?string
+    public function offsetGet(mixed $identifier): ?string
     {
         if (isset($this->overrideLabels[$identifier])) {
             return $this->overrideLabels[$identifier];
@@ -141,31 +111,20 @@ class Labels implements ComponentAware, RenderingContextAware, \ArrayAccess, Con
 
     /**
      * Set an override language label
-     *
-     * @param mixed $identifier
-     * @param mixed $value
-     * @return void
      */
-    public function offsetSet($identifier, $value): void
+    public function offsetSet(mixed $identifier, mixed $value): void
     {
         $this->overrideLabels[$identifier] = $value;
     }
 
     /**
      * Remove an override language label
-     *
-     * @param mixed $identifier
-     * @return void
      */
-    public function offsetUnset($identifier): void
+    public function offsetUnset(mixed $identifier): void
     {
         unset($this->overrideLabels[$identifier]);
     }
 
-    /**
-     * @param string $identifier
-     * @return string
-     */
     protected function generateLabelIdentifier(string $identifier): string
     {
         if (!$this->labelsFile) {
@@ -174,15 +133,12 @@ class Labels implements ComponentAware, RenderingContextAware, \ArrayAccess, Con
         return sprintf('LLL:%s:%s', $this->labelsFile, $identifier);
     }
 
-    /**
-     * @return string
-     */
     protected function generateLabelFilePath(): string
     {
         $componentLoader = GeneralUtility::makeInstance(ComponentLoader::class);
         $componentFile = $componentLoader->findComponent($this->componentNamespace);
-        $componentName = basename($componentFile, '.html');
-        $componentPath = dirname($componentFile);
+        $componentName = basename((string) $componentFile, '.html');
+        $componentPath = dirname((string) $componentFile);
         return $componentPath . DIRECTORY_SEPARATOR . $componentName . '.labels.xlf';
     }
 }

--- a/Classes/Domain/Model/LanguageNavigationItem.php
+++ b/Classes/Domain/Model/LanguageNavigationItem.php
@@ -49,9 +49,9 @@ class LanguageNavigationItem extends NavigationItem
      *
      * @param string $title             title of the item
      * @param Typolink $link            link of the item
-     * @param boolean $current          true if item represents the current page
-     * @param boolean $active           true if item is part of current rootline
-     * @param boolean $available        true if current page is translated to language
+     * @param bool $current          true if item represents the current page
+     * @param bool $active           true if item is part of current rootline
+     * @param bool $available        true if current page is translated to language
      * @param int $languageId           UID of the sys_language record
      * @param string $locale            Locale definition for language
      * @param string $twoLetterIsoCode  ISO code for language

--- a/Classes/Domain/Model/LanguageNavigationItem.php
+++ b/Classes/Domain/Model/LanguageNavigationItem.php
@@ -11,52 +11,38 @@ class LanguageNavigationItem extends NavigationItem
 {
     /**
      * Availability of translation for the specific page
-     *
-     * @var boolean
      */
-    protected $available = false;
+    protected bool $available = false;
 
     /**
      * UID of the sys_language record
-     *
-     * @var int
      */
-    protected $languageId;
+    protected int $languageId;
 
     /**
      * Locale definition for language
-     *
-     * @var string
      */
-    protected $locale;
+    protected string $locale;
 
     /**
      * ISO code for language
-     *
-     * @var string
      */
-    protected $twoLetterIsoCode;
+    protected string $twoLetterIsoCode;
 
     /**
      * Hreflang identifier for language
-     *
-     * @var string
      */
-    protected $hreflang;
+    protected string $hreflang;
 
     /**
      * Directionality of text in the language (ltr or rtl)
-     *
-     * @var string
      */
-    protected $direction;
+    protected string $direction;
 
     /**
      * Flag name for language
-     *
-     * @var string
      */
-    protected $flag;
+    protected string $flag;
 
     /**
      * Creates a navigation item object
@@ -115,7 +101,6 @@ class LanguageNavigationItem extends NavigationItem
      * @param array $navigationItem  respected properties that will become part of the data structure:
      *                               title, link, target, current, active, available, languageId, locale,
      *                               twoLetterIsoCode, hreflang, direction, flag, data
-     * @return self
      */
     public static function fromArray(array $navigationItem): self
     {

--- a/Classes/Domain/Model/Link.php
+++ b/Classes/Domain/Model/Link.php
@@ -12,72 +12,52 @@ class Link implements ConstructibleFromString
 {
     /**
      * Target URI of the link
-     *
-     * @var string
      */
-    protected $uri = '';
+    protected string $uri = '';
 
     /**
      * URI scheme, e. g. https://
-     *
-     * @var string|null
      */
-    protected $scheme;
+    protected ?string $scheme;
 
     /**
      * Host name, e. g. domain.tld
-     *
-     * @var string|null
      */
-    protected $host;
+    protected ?string $host;
 
     /**
      * Port number, e. g. 8080
-     *
-     * @var int|null
      */
-    protected $port;
+    protected ?int $port;
 
     /**
      * HTTP Basic Auth User
-     *
-     * @var string|null
      */
-    protected $user;
+    protected ?string $user;
 
     /**
      * HTTP Basic Auth Password
-     *
-     * @var string|null
      */
-    protected $pass;
+    protected ?string $pass;
 
     /**
      * Path part of the URI, e. g. /my/path/file.html
-     *
-     * @var string|null
      */
-    protected $path;
+    protected ?string $path;
 
     /**
      * Query string of the URI (without the leading ?),
      * e. g. myParam=myValue&anotherParam=anotherValue
-     *
-     * @var string|null
      */
-    protected $query;
+    protected ?string $query;
 
     /**
      * Fragment/Anchor of the URI (without the leading #)
-     *
-     * @var string|null
      */
-    protected $fragment;
+    protected ?string $fragment;
 
     /**
      * Creates a link data structure from an URI
-     *
-     * @param string $uri
      */
     public function __construct(string $uri)
     {

--- a/Classes/Domain/Model/LocalFile.php
+++ b/Classes/Domain/Model/LocalFile.php
@@ -14,22 +14,17 @@ class LocalFile extends File
 {
     /**
      * Type of file to differentiate implementations in Fluid templates
-     *
-     * @var string
      */
-    protected $type = 'LocalFile';
+    protected string $type = 'LocalFile';
 
     /**
      * Absolute path to the local file
-     *
-     * @var string
      */
-    protected $filePath = '';
+    protected string $filePath = '';
 
     /**
      * Creates an file object for a local file resource
      *
-     * @param string $filePath
      * @throws InvalidFilePathException
      */
     public function __construct(string $filePath)

--- a/Classes/Domain/Model/LocalImage.php
+++ b/Classes/Domain/Model/LocalImage.php
@@ -14,22 +14,17 @@ class LocalImage extends Image
 {
     /**
      * Type of image to differentiate implementations in Fluid templates
-     *
-     * @var string
      */
-    protected $type = 'LocalImage';
+    protected string $type = 'LocalImage';
 
     /**
      * Absolute path to the local file
-     *
-     * @var string
      */
-    protected $filePath = '';
+    protected string $filePath = '';
 
     /**
      * Creates an image object for a local image resource
      *
-     * @param string $filePath
      * @throws InvalidFilePathException
      */
     public function __construct(string $filePath)

--- a/Classes/Domain/Model/Navigation.php
+++ b/Classes/Domain/Model/Navigation.php
@@ -17,12 +17,10 @@ class Navigation implements \Iterator, \Countable, ConstructibleFromArray
      *
      * @var NavigationItem[]
      */
-    protected $items = [];
+    protected array $items = [];
 
     /**
      * Initializes a navigation object from a TYPO3 navigation array
-     *
-     * @param array $items
      */
     public function __construct(array $items)
     {
@@ -31,8 +29,6 @@ class Navigation implements \Iterator, \Countable, ConstructibleFromArray
 
     /**
      * Initializes a navigation object from a TYPO3 navigation array
-     *
-     * @param array $items
      */
     public static function fromArray(array $items): self
     {
@@ -85,11 +81,8 @@ class Navigation implements \Iterator, \Countable, ConstructibleFromArray
 
     /**
      * Makes sure that the provided item is a valid data structure
-     *
-     * @param mixed $item
-     * @return NavigationItem|null
      */
-    protected function sanitizeNavigationItem($item): ?NavigationItem
+    protected function sanitizeNavigationItem(mixed $item): ?NavigationItem
     {
         if ($item instanceof NavigationItem) {
             return $item;

--- a/Classes/Domain/Model/NavigationItem.php
+++ b/Classes/Domain/Model/NavigationItem.php
@@ -25,19 +25,19 @@ class NavigationItem implements ConstructibleFromArray
      * Indicates whether the navigation item is part of the current rootline
      * (parent page of the current page OR current page)
      */
-    protected boolean $active = false;
+    protected bool $active = false;
 
     /**
      * Indicates whether the navigation item represents the current page
      * (note that active will be true as well)
      */
-    protected boolean $current = false;
+    protected bool $current = false;
 
     /**
      * Indicates whether the navigation item is a spacer item without real
      * functionality
      */
-    protected boolean $spacer = false;
+    protected bool $spacer = false;
 
     /**
      * Submenu of the navigation item
@@ -54,9 +54,9 @@ class NavigationItem implements ConstructibleFromArray
      *
      * @param string $title         title of the item
      * @param Typolink $link        link of the item
-     * @param boolean $current      true if item represents the current page
-     * @param boolean $active       true if item is part of current rootline
-     * @param boolean $spacer       true if item is a spacer item
+     * @param bool $current      true if item represents the current page
+     * @param bool $active       true if item is part of current rootline
+     * @param bool $spacer       true if item is a spacer item
      * @param Navigation $children  sub navigation
      * @param array $data           raw item data
      */

--- a/Classes/Domain/Model/NavigationItem.php
+++ b/Classes/Domain/Model/NavigationItem.php
@@ -13,55 +13,41 @@ class NavigationItem implements ConstructibleFromArray
 {
     /**
      * Title of the navigation item
-     *
-     * @var string
      */
-    protected $title;
+    protected string $title;
 
     /**
      * Link of the navigation item
-     *
-     * @var Typolink
      */
-    protected $link;
+    protected Typolink $link;
 
     /**
      * Indicates whether the navigation item is part of the current rootline
      * (parent page of the current page OR current page)
-     *
-     * @var boolean
      */
-    protected $active = false;
+    protected boolean $active = false;
 
     /**
      * Indicates whether the navigation item represents the current page
      * (note that active will be true as well)
-     *
-     * @var boolean
      */
-    protected $current = false;
+    protected boolean $current = false;
 
     /**
      * Indicates whether the navigation item is a spacer item without real
      * functionality
-     *
-     * @var boolean
      */
-    protected $spacer = false;
+    protected boolean $spacer = false;
 
     /**
      * Submenu of the navigation item
-     *
-     * @var Navigation
      */
-    protected $children;
+    protected Navigation $children;
 
     /**
      * Raw data of the navigation item, e. g. the pages record
-     *
-     * @var array
      */
-    protected $data = [];
+    protected array $data = [];
 
     /**
      * Creates a navigation item object
@@ -106,7 +92,6 @@ class NavigationItem implements ConstructibleFromArray
      *
      * @param array $navigationItem  respected properties that will become part of the data structure:
      *                               title, link, target, current, active, spacer, children, data
-     * @return self
      */
     public static function fromArray(array $navigationItem): self
     {

--- a/Classes/Domain/Model/PlaceholderImage.php
+++ b/Classes/Domain/Model/PlaceholderImage.php
@@ -9,30 +9,21 @@ class PlaceholderImage extends Image
 {
     /**
      * Type of image to differentiate implementations in Fluid templates
-     *
-     * @var string
      */
-    protected $type = 'PlaceholderImage';
+    protected string $type = 'PlaceholderImage';
 
     /**
      * Width of the placeholder image
-     *
-     * @var integer
      */
-    protected $width = 0;
+    protected int $width = 0;
 
     /**
      * Height of the placeholder image
-     *
-     * @var integer
      */
-    protected $height = 0;
+    protected int $height = 0;
 
     /**
      * Creates an image object for a placeholder image
-     *
-     * @param integer $width
-     * @param integer $height
      */
     public function __construct(int $width, int $height)
     {

--- a/Classes/Domain/Model/RemoteFile.php
+++ b/Classes/Domain/Model/RemoteFile.php
@@ -11,22 +11,17 @@ class RemoteFile extends File
 {
     /**
      * Type of file to differentiate implementations in Fluid templates
-     *
-     * @var string
      */
-    protected $type = 'RemoteFile';
+    protected string $type = 'RemoteFile';
 
     /**
      * URI to the remote file
-     *
-     * @var string
      */
-    protected $uri = '';
+    protected string $uri = '';
 
     /**
      * Creates a file object for a remote resource
      *
-     * @param string $uri
      * @throws InvalidRemoteFileException
      */
     public function __construct(string $uri)
@@ -48,9 +43,6 @@ class RemoteFile extends File
 
     /**
      * Checks if the provided uri is a valid remote uri
-     *
-     * @param string $uri
-     * @return boolean
      */
     protected static function isRemoteUri(string $uri): bool
     {

--- a/Classes/Domain/Model/RemoteImage.php
+++ b/Classes/Domain/Model/RemoteImage.php
@@ -11,22 +11,17 @@ class RemoteImage extends Image
 {
     /**
      * Type of image to differentiate implementations in Fluid templates
-     *
-     * @var string
      */
-    protected $type = 'RemoteImage';
+    protected string $type = 'RemoteImage';
 
     /**
      * URI to the remote image
-     *
-     * @var string
      */
-    protected $uri = '';
+    protected string $uri = '';
 
     /**
      * Creates an image object for a remote image resource
      *
-     * @param string $uri
      * @throws InvalidRemoteImageException
      */
     public function __construct(string $uri)
@@ -48,9 +43,6 @@ class RemoteImage extends Image
 
     /**
      * Checks if the provided uri is a valid remote uri
-     *
-     * @param string $uri
-     * @return boolean
      */
     protected static function isRemoteUri(string $uri): bool
     {

--- a/Classes/Domain/Model/Slot.php
+++ b/Classes/Domain/Model/Slot.php
@@ -30,7 +30,7 @@ class Slot implements EscapedParameter, ConstructibleFromString, ConstructibleFr
 
     public function count(): int
     {
-        return strlen($this->html);
+        return strlen((string) $this->html);
     }
 
     public function __toString(): string

--- a/Classes/Domain/Model/Traits/FalFileTrait.php
+++ b/Classes/Domain/Model/Traits/FalFileTrait.php
@@ -11,27 +11,14 @@ use TYPO3\CMS\Core\Resource\FileInterface;
 trait FalFileTrait
 {
     /**
-     * FAL object
-     *
-     * @var FileInterface
-     */
-    protected $file;
-
-    /**
      * Creates an file object as a wrapper around a FAL object
-     *
-     * @param FileInterface $file
      */
-    public function __construct(FileInterface $file)
+    public function __construct(protected FileInterface $file)
     {
-        $this->file = $file;
     }
 
     /**
      * Creates a file object based on a FAL file uid
-     *
-     * @param integer $value
-     * @return File
      */
     public static function fromInteger(int $value): File
     {

--- a/Classes/Domain/Model/Typolink.php
+++ b/Classes/Domain/Model/Typolink.php
@@ -9,7 +9,7 @@ use SMS\FluidComponents\Interfaces\ConstructibleFromInteger;
 use TYPO3\CMS\Core\LinkHandling\LinkService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
-use TYPO3\CMS\Frontend\Service\TypoLinkCodecService;
+use TYPO3\CMS\Core\LinkHandling\TypoLinkCodecService;
 
 /**
  * Data Structure to provide information extracted from a Typolink string

--- a/Classes/Domain/Model/Typolink.php
+++ b/Classes/Domain/Model/Typolink.php
@@ -20,32 +20,25 @@ class Typolink extends Link implements ConstructibleFromInteger, ConstructibleFr
     /**
      * Data interpretation of the provided TYPO3 uri
      *
-     * @var array
      * @see LinkService::resolve()
      */
-    protected $originalLink = [];
+    protected array $originalLink = [];
 
     /**
      * Link target window of the Typolink
      * e. g. _blank
-     *
-     * @var string
      */
-    protected $target = '';
+    protected string $target = '';
 
     /**
      * Additional CSS classes for the html element
-     *
-     * @var string
      */
-    protected $class = '';
+    protected string $class = '';
 
     /**
      * Title attribute for the html element
-     *
-     * @var string
      */
-    protected $title = '';
+    protected string $title = '';
 
     /**
      * Creates a Typolink data structure from a Typolink string
@@ -80,9 +73,6 @@ class Typolink extends Link implements ConstructibleFromInteger, ConstructibleFr
 
     /**
      * Creates a Typolink data structure from a page uid
-     *
-     * @param integer $pageUid
-     * @return self
      */
     public static function fromInteger(int $pageUid): self
     {
@@ -98,8 +88,6 @@ class Typolink extends Link implements ConstructibleFromInteger, ConstructibleFr
      * - class
      * - title
      *
-     * @param array $typolinkData
-     * @return self
      * @throws InvalidArgumentException
      */
     public static function fromArray(array $typolinkData): self

--- a/Classes/Fluid/ViewHelper/ComponentRenderer.php
+++ b/Classes/Fluid/ViewHelper/ComponentRenderer.php
@@ -177,14 +177,12 @@ class ComponentRenderer extends AbstractViewHelper
     {
         // Create a new rendering context for the component file
         $renderingContext = $this->getRenderingContext();
-        if ((new Typo3Version())->getMajorVersion() < 12 && $this->renderingContext->getControllerContext()) {
-            $renderingContext->setControllerContext($this->renderingContext->getControllerContext());
-        } else {
-            // set the original request to preserve the request attributes
-            // some ViewHelpers expect a ServerRequestInterface or other attributes inside the request
-            // e.g. f:uri.action, f:page.action
-            $renderingContext->setRequest($this->renderingContext->getRequest());
-        }
+
+        // set the original request to preserve the request attributes
+        // some ViewHelpers expect a ServerRequestInterface or other attributes inside the request
+        // e.g. f:uri.action, f:page.action
+        $renderingContext->setRequest($this->renderingContext->getRequest());
+
         $renderingContext->setViewHelperVariableContainer($this->renderingContext->getViewHelperVariableContainer());
         if (static::shouldUseTemplatePaths()) {
             $renderingContext->getTemplatePaths()->setPartialRootPaths(

--- a/Classes/Fluid/ViewHelper/ComponentRenderer.php
+++ b/Classes/Fluid/ViewHelper/ComponentRenderer.php
@@ -17,11 +17,11 @@ use SMS\FluidComponents\ViewHelpers\ComponentViewHelper;
 use SMS\FluidComponents\ViewHelpers\ContentViewHelper;
 use SMS\FluidComponents\ViewHelpers\ParamViewHelper;
 use TYPO3\CMS\Core\Configuration\Features;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextFactory;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
+use TYPO3Fluid\Fluid\Core\Parser\ParsedTemplateInterface;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\EscapingNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
@@ -33,7 +33,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 
 class ComponentRenderer extends AbstractViewHelper
 {
-    const DEFAULT_SLOT = 'content';
+    public const DEFAULT_SLOT = 'content';
 
     protected $reservedArguments = [
         'class',
@@ -44,17 +44,13 @@ class ComponentRenderer extends AbstractViewHelper
 
     /**
      * Namespace of the component the viewhelper should render
-     *
-     * @var string
      */
-    protected $componentNamespace;
+    protected string $componentNamespace;
 
     /**
      * Cache for component template instance used for rendering
-     *
-     * @var \TYPO3Fluid\Fluid\Core\Parser\ParsedTemplateInterface
      */
-    protected $parsedTemplate;
+    protected ParsedTemplateInterface $parsedTemplate;
 
     /**
      * Cache of component argument definitions; the key is the component namespace, and the
@@ -62,76 +58,36 @@ class ComponentRenderer extends AbstractViewHelper
      *
      * In our benchmarks, this cache leads to a 40% improvement when using a certain
      * ViewHelper class many times throughout the rendering process.
-     * @var array
      */
-    protected static $componentArgumentDefinitionCache = [];
+    protected static array $componentArgumentDefinitionCache = [];
 
     /**
      * Cache of component prefixer objects
-     *
-     * @var array
      */
-    protected static $componentPrefixerCache = [];
+    protected static array $componentPrefixerCache = [];
 
     /**
-     * Components are HTML markup which should not be escaped
-     *
-     * @var boolean
-     */
+    * Components are HTML markup which should not be escaped
+    */
     protected $escapeOutput = false;
 
     /**
      * Children should be treated just like an argument
-     *
-     * @var boolean
      */
     protected $escapeChildren = true;
 
-    /**
-     * @var ComponentLoader
-     */
-    protected ComponentLoader $componentLoader;
-
-    /**
-     * @var ComponentSettings
-     */
-    protected ComponentSettings $componentSettings;
-
-    /**
-     * @var ComponentArgumentConverter
-     */
-    protected ComponentArgumentConverter $componentArgumentConverter;
-
-    /**
-     * @var ContainerInterface
-     */
-    protected ContainerInterface $container;
-
-    /**
-     * @param ComponentLoader $componentLoader
-     * @param ComponentSettings $componentSettings
-     * @param ComponentArgumentConverter $componentArgumentConverter
-     * @param ContainerInterface $container
-     */
     public function __construct(
-        ComponentLoader $componentLoader,
-        ComponentSettings $componentSettings,
-        ComponentArgumentConverter $componentArgumentConverter,
-        ContainerInterface $container
+        protected ComponentLoader $componentLoader,
+        protected ComponentSettings $componentSettings,
+        protected ComponentArgumentConverter $componentArgumentConverter,
+        protected ContainerInterface $container
     ) {
-        $this->componentLoader = $componentLoader;
-        $this->componentSettings = $componentSettings;
-        $this->componentArgumentConverter = $componentArgumentConverter;
-        $this->container = $container;
     }
 
     /**
      * Sets the namespace of the component the viewhelper should render
-     *
-     * @param string $componentNamespace
-     * @return self
      */
-    public function setComponentNamespace($componentNamespace)
+    public function setComponentNamespace(string $componentNamespace): self
     {
         $this->componentNamespace = $componentNamespace;
         return $this;
@@ -139,41 +95,28 @@ class ComponentRenderer extends AbstractViewHelper
 
     /**
      * Returns the namespace of the component the viewhelper renders
-     *
-     * @return void
      */
-    public function getComponentNamespace()
+    public function getComponentNamespace(): string
     {
         return $this->componentNamespace;
     }
 
-    /**
-     * Returns the component prefix
-     *
-     * @return string
-     */
-    public function getComponentClass()
+    public function getComponentClass(): string
     {
         return $this->getComponentPrefixer()->prefix($this->componentNamespace);
     }
 
-    /**
-     * Returns the component prefix
-     *
-     * @return string
-     */
-    public function getComponentPrefix()
+    public function getComponentPrefix(): string
     {
         return $this->getComponentClass() . $this->getComponentPrefixer()->getSeparator();
     }
 
     /**
      * Renders the component the viewhelper is responsible for
-     * TODO this can probably be improved by using renderComponent() directly
+     * TODO: this can probably be improved by using renderComponent() directly
      *
-     * @return string
      */
-    public function render()
+    public function render(): string
     {
         // Create a new rendering context for the component file
         $renderingContext = $this->getRenderingContext();
@@ -230,9 +173,7 @@ class ComponentRenderer extends AbstractViewHelper
 
             $this->parsedTemplate = $renderingContext->getTemplateParser()->getOrParseAndStoreTemplate(
                 $this->getTemplateIdentifier($componentFile),
-                function () use ($componentFile) {
-                    return file_get_contents($componentFile);
-                }
+                fn() => file_get_contents($componentFile)
             );
         }
 
@@ -292,7 +233,7 @@ class ComponentRenderer extends AbstractViewHelper
         &$initializationPhpCode,
         ViewHelperNode $node,
         TemplateCompiler $compiler
-    ) {
+    ): string {
         $allowedSlots = [];
         foreach ($node->getArgumentDefinitions() as $definition) {
             if (is_a($definition->getType(), Slot::class, true)) {
@@ -316,7 +257,7 @@ class ComponentRenderer extends AbstractViewHelper
 
         return sprintf(
             '%s::renderComponent(%s, %s, $renderingContext, %s)',
-            get_class($this),
+            static::class,
             $argumentsName,
             $closureName,
             var_export($this->componentNamespace, true)
@@ -325,19 +266,13 @@ class ComponentRenderer extends AbstractViewHelper
 
     /**
      * Replacement for renderStatic() to provide component namespace to ViewHelper
-     *
-     * @param array $arguments
-     * @param \Closure $renderChildrenClosure
-     * @param RenderingContextInterface $renderingContext
-     * @param string $componentNamespace
-     * @return mixed
      */
     public static function renderComponent(
         array $arguments,
         \Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext,
-        $componentNamespace
-    ) {
+        string $componentNamespace
+    ): mixed {
         $container = GeneralUtility::makeInstance(ContainerInterface::class);
         $componentRenderer = $container->get(static::class);
         $componentRenderer->setComponentNamespace($componentNamespace);
@@ -353,10 +288,9 @@ class ComponentRenderer extends AbstractViewHelper
     /**
      * Initializes the component arguments based on the component definition
      *
-     * @return void
      * @throws Exception
      */
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument(
             'class',
@@ -400,10 +334,8 @@ class ComponentRenderer extends AbstractViewHelper
      * method must not be called, obviously.
      *
      * @throws Exception
-     * @param array $arguments
-     * @return void
      */
-    public function validateAdditionalArguments(array $arguments)
+    public function validateAdditionalArguments(array $arguments): void
     {
         if (!empty($arguments)) {
             throw new Exception(
@@ -421,10 +353,9 @@ class ComponentRenderer extends AbstractViewHelper
     /**
      * Validate arguments, and throw exception if arguments do not validate.
      *
-     * @return void
      * @throws \InvalidArgumentException
      */
-    public function validateArguments()
+    public function validateArguments(): void
     {
         $argumentDefinitions = $this->prepareArguments();
         foreach ($argumentDefinitions as $argumentName => $registeredArgument) {
@@ -433,7 +364,7 @@ class ComponentRenderer extends AbstractViewHelper
                 $defaultValue = $registeredArgument->getDefaultValue();
                 $type = $registeredArgument->getType();
                 if ($value !== $defaultValue && $type !== 'mixed') {
-                    $givenType = is_object($value) ? get_class($value) : gettype($value);
+                    $givenType = is_object($value) ? $value::class : gettype($value);
                     if (!$this->isValidType($type, $value)
                         && !$this->componentArgumentConverter->canTypeBeConvertedToType($givenType, $type)
                     ) {
@@ -450,10 +381,8 @@ class ComponentRenderer extends AbstractViewHelper
 
     /**
      * Creates ViewHelper arguments based on the params defined in the component definition
-     *
-     * @return void
      */
-    protected function initializeComponentParams()
+    protected function initializeComponentParams(): void
     {
         $renderingContext = $this->getRenderingContext();
 
@@ -494,9 +423,7 @@ class ComponentRenderer extends AbstractViewHelper
 
                 // Use tag content as default value instead of attribute
                 if (!isset($param['default'])) {
-                    $param['default'] = implode('', array_map(function ($node) use ($renderingContext) {
-                        return $node->evaluate($renderingContext);
-                    }, $paramNode->getChildNodes()));
+                    $param['default'] = implode('', array_map(fn($node) => $node->evaluate($renderingContext), $paramNode->getChildNodes()));
                     $param['default'] = $param['default'] === '' ? null : $param['default'];
                 }
 
@@ -541,10 +468,6 @@ class ComponentRenderer extends AbstractViewHelper
 
     /**
      * Extracts all <fc:content /> ViewHelpers from Fluid template node
-     *
-     * @param NodeInterface $node
-     * @param RenderingContext $renderingContext
-     * @return array
      */
     protected function extractContentViewHelpers(NodeInterface $node, RenderingContext $renderingContext): array
     {
@@ -562,10 +485,6 @@ class ComponentRenderer extends AbstractViewHelper
 
     /**
      * Extract all ViewHelpers of a certain type from a Fluid template node
-     *
-     * @param NodeInterface $node
-     * @param string $viewHelperClassName
-     * @return array
      */
     protected function extractViewHelpers(NodeInterface $node, string $viewHelperClassName): array
     {
@@ -591,10 +510,8 @@ class ComponentRenderer extends AbstractViewHelper
 
     /**
      * Returns an identifier by which fluid templates will be stored in the cache
-     *
-     * @return string
      */
-    protected function getTemplateIdentifier(string $pathAndFilename, string $prefix = 'fluidcomponent')
+    protected function getTemplateIdentifier(string $pathAndFilename, string $prefix = 'fluidcomponent'): string
     {
         $templateModifiedTimestamp = $pathAndFilename !== 'php://stdin' && file_exists($pathAndFilename) ? filemtime($pathAndFilename) : 0;
         return sprintf(
@@ -607,10 +524,8 @@ class ComponentRenderer extends AbstractViewHelper
 
     /**
      * Returns the prefixer object responsible for the current component namespaces
-     *
-     * @return ComponentPrefixerInterface
      */
-    protected function getComponentPrefixer()
+    protected function getComponentPrefixer(): ComponentPrefixerInterface
     {
         if (!isset(self::$componentPrefixerCache[$this->componentNamespace])) {
             if (isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['prefixer']) &&
@@ -619,7 +534,7 @@ class ComponentRenderer extends AbstractViewHelper
                 arsort($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['prefixer']);
                 foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['prefixer'] as $namespace => $prefixer) {
                     $namespace = ltrim($namespace, '\\');
-                    if (strpos($this->componentNamespace, $namespace) === 0) {
+                    if (str_starts_with($this->componentNamespace, $namespace)) {
                         $componentPrefixerClass = $prefixer;
                         break;
                     }
@@ -649,9 +564,6 @@ class ComponentRenderer extends AbstractViewHelper
         return self::$componentPrefixerCache[$this->componentNamespace];
     }
 
-    /**
-     * @return RenderingContext
-     */
     protected function getRenderingContext(): RenderingContext
     {
         if ($this->container->has(RenderingContextFactory::class)) {
@@ -661,9 +573,6 @@ class ComponentRenderer extends AbstractViewHelper
         }
     }
 
-    /**
-     * @return bool
-     */
     protected static function shouldUseTemplatePaths(): bool
     {
         static $assertion = null;

--- a/Classes/Fluid/ViewHelper/ComponentResolver.php
+++ b/Classes/Fluid/ViewHelper/ComponentResolver.php
@@ -63,10 +63,6 @@ class ComponentResolver extends ViewHelperResolver
             if ($this->container->has($viewHelperClassName)) {
                 /** @var ViewHelperInterface $viewHelperInstance */
                 $viewHelperInstance = $this->container->get($viewHelperClassName);
-            } elseif ((new Typo3Version())->getMajorVersion() < 12) {
-                $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-                /** @var ViewHelperInterface $viewHelperInstance */
-                $viewHelperInstance = $objectManager->get($viewHelperClassName);
             } else {
                 /** @var ViewHelperInterface $viewHelperInstance */
                 $viewHelperInstance = new $viewHelperClassName;

--- a/Classes/Fluid/ViewHelper/ComponentResolver.php
+++ b/Classes/Fluid/ViewHelper/ComponentResolver.php
@@ -9,9 +9,7 @@ use SMS\FluidComponents\Utility\ComponentLoader;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\DependencyInjection\FailsafeContainer;
 use TYPO3\CMS\Core\Http\ApplicationType;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Core\Parser\Exception as ParserException;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;
@@ -44,9 +42,6 @@ class ComponentResolver extends ViewHelperResolver
     /**
      * Uses Symfony dependency injection to inject ComponentRenderer into
      * Fluid viewhelper processing
-     *
-     * @param string $viewHelperClassName
-     * @return \TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface
      */
     public function createViewHelperInstanceFromClassName($viewHelperClassName): ViewHelperInterface
     {
@@ -127,7 +122,7 @@ class ComponentResolver extends ViewHelperResolver
      * @param string $methodIdentifier Method identifier, might be hierarchical like "link.url"
      * @return string The fully qualified class name of the viewhelper
      */
-    protected function resolveComponentName($namespaceIdentifier, $methodIdentifier)
+    protected function resolveComponentName(string $namespaceIdentifier, string $methodIdentifier): string
     {
         $explodedViewHelperName = explode('.', $methodIdentifier);
         if (count($explodedViewHelperName) > 1) {
@@ -140,7 +135,7 @@ class ComponentResolver extends ViewHelperResolver
         $namespaces = (array) $this->namespaces[$namespaceIdentifier];
 
         do {
-            $name = rtrim(array_pop($namespaces), '\\') . '\\' . $className;
+            $name = rtrim((string) array_pop($namespaces), '\\') . '\\' . $className;
         } while (!$componentLoader->findComponent($name) && count($namespaces));
 
         return $name;
@@ -148,11 +143,8 @@ class ComponentResolver extends ViewHelperResolver
 
     /**
      * Generates a valid PHP class name from the resolved viewhelper class
-     *
-     * @param string $resolvedViewHelperClassName
-     * @return void
      */
-    protected function generateViewHelperClassName($resolvedViewHelperClassName)
+    protected function generateViewHelperClassName(string $resolvedViewHelperClassName): string
     {
         return implode('\\', array_map('ucfirst', explode('.', $resolvedViewHelperClassName)));
     }

--- a/Classes/Fluid/ViewHelper/ViewHelperResolverFactory.php
+++ b/Classes/Fluid/ViewHelper/ViewHelperResolverFactory.php
@@ -8,13 +8,10 @@ use Psr\Container\ContainerInterface;
 use SMS\FluidComponents\Fluid\ViewHelper\ComponentResolver;
 use TYPO3\CMS\Fluid\Core\ViewHelper\ViewHelperResolverFactoryInterface;
 
-final class ViewHelperResolverFactory implements ViewHelperResolverFactoryInterface
+final readonly class ViewHelperResolverFactory implements ViewHelperResolverFactoryInterface
 {
-    private ContainerInterface $container;
-
-    public function __construct(ContainerInterface $container)
+    public function __construct(private ContainerInterface $container)
     {
-        $this->container = $container;
     }
 
     public function create(): ComponentResolver

--- a/Classes/Interfaces/ConstructibleFromArray.php
+++ b/Classes/Interfaces/ConstructibleFromArray.php
@@ -11,9 +11,6 @@ interface ConstructibleFromArray
 {
     /**
      * Creates an instance of the class based on the provided array
-     *
-     * @param array $value
-     * @return object
      */
-    public static function fromArray(array $value);
+    public static function fromArray(array $value): object;
 }

--- a/Classes/Interfaces/ConstructibleFromArray.php
+++ b/Classes/Interfaces/ConstructibleFromArray.php
@@ -12,5 +12,5 @@ interface ConstructibleFromArray
     /**
      * Creates an instance of the class based on the provided array
      */
-    public static function fromArray(array $value): object;
+    public static function fromArray(array $value): ?object;
 }

--- a/Classes/Interfaces/ConstructibleFromDateTimeImmutable.php
+++ b/Classes/Interfaces/ConstructibleFromDateTimeImmutable.php
@@ -11,9 +11,6 @@ interface ConstructibleFromDateTimeImmutable
 {
     /**
      * Creates an instance of the class based on the provided DateTimeImmutable
-     *
-     * @param \DateTimeImmutable $value
-     * @return object
      */
-    public static function fromDateTimeImmutable(\DateTimeImmutable $value);
+    public static function fromDateTimeImmutable(\DateTimeImmutable $value): object;
 }

--- a/Classes/Interfaces/ConstructibleFromFileInterface.php
+++ b/Classes/Interfaces/ConstructibleFromFileInterface.php
@@ -14,9 +14,6 @@ interface ConstructibleFromFileInterface
     /**
      * Creates an instance of the class based on the provided implementation
      * of FileInterface
-     *
-     * @param FileInterface $value
-     * @return object
      */
-    public static function fromFileInterface(FileInterface $value);
+    public static function fromFileInterface(FileInterface $value): object;
 }

--- a/Classes/Interfaces/ConstructibleFromInteger.php
+++ b/Classes/Interfaces/ConstructibleFromInteger.php
@@ -11,9 +11,6 @@ interface ConstructibleFromInteger
 {
     /**
      * Creates an instance of the class based on the provided integer
-     *
-     * @param integer $value
-     * @return object
      */
-    public static function fromInteger(int $value);
+    public static function fromInteger(int $value): object;
 }

--- a/Classes/Interfaces/ConstructibleFromNull.php
+++ b/Classes/Interfaces/ConstructibleFromNull.php
@@ -10,8 +10,6 @@ interface ConstructibleFromNull
 {
     /**
      * Creates an instance of the class
-     *
-     * @return object
      */
-    public static function fromNull();
+    public static function fromNull(): object;
 }

--- a/Classes/Service/XsdGenerator.php
+++ b/Classes/Service/XsdGenerator.php
@@ -9,22 +9,16 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 
 class XsdGenerator
 {
-    /**
-     * @var object|\SMS\FluidComponents\Utility\ComponentLoader
-     */
-    private $componentLoader;
-
-    public function __construct(ComponentLoader $componentLoader)
+    public function __construct(private readonly ComponentLoader $componentLoader)
     {
-        $this->componentLoader = $componentLoader;
     }
 
     /**
-     * @param $componentName Name of component without namespace, f.e. 'atom.button'
+     * @param string $componentName Name of component without namespace, f.e. 'atom.button'
      * @param ArgumentDefinition[] $arguments
      * @return string
      */
-    protected function generateXsdForComponent($componentName, $arguments)
+    protected function generateXsdForComponent(string $componentName, array $arguments): string
     {
         $xsd = '<xsd:element name="' . $componentName . '">
         <xsd:annotation>
@@ -38,7 +32,7 @@ class XsdGenerator
             $requiredTag = $argumentDefinition->isRequired() ? ' use="required"' : '';
             try {
                 $defaultTag = (string)$argumentDefinition->getDefaultValue() !== '' ? ' default="' . $argumentDefinition->getDefaultValue() . '"' : '';
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 $defaultTag = '';
             }
             $xsd .= "\n" . '            <xsd:attribute type="xsd:string" name="' . $argumentDefinition->getName() . '"' . $requiredTag . $defaultTag . '>
@@ -80,8 +74,8 @@ class XsdGenerator
     private function getTagName($nameSpace, $componentName)
     {
         $tagName = '';
-        if (strpos($componentName, $nameSpace) === 0) {
-            $tagNameWithoutNameSpace = substr($componentName, strlen($nameSpace) + 1);
+        if (str_starts_with((string) $componentName, (string) $nameSpace)) {
+            $tagNameWithoutNameSpace = substr((string) $componentName, strlen((string) $nameSpace) + 1);
             $tagName = lcfirst(str_replace('\\', '.', $tagNameWithoutNameSpace));
         }
         return $tagName;
@@ -89,16 +83,13 @@ class XsdGenerator
 
     /**
      * returns only the upper chars of a given string
-     *
-     * @param $string
-     * @return string
      */
-    private function strUpperChars($string)
+    private function strUpperChars(string $string): string
     {
         $output = '';
-        $strLength = strlen($string);
+        $strLength = strlen((string) $string);
         for ($i = 0; $i < $strLength; $i++) {
-            if (ctype_upper($string[$i])) {
+            if (ctype_upper((string) $string[$i])) {
                 $output .= $string[$i];
             }
         }
@@ -108,11 +99,8 @@ class XsdGenerator
     /**
      * returns default prefix for a namespace if defined
      * otherwise it builds a prefix from the extension name part of the namespace
-     *
-     * @param $namespace
-     * @return int|string
      */
-    protected function getDefaultPrefixForNamespace($namespace)
+    protected function getDefaultPrefixForNamespace(string $namespace): int|string
     {
         $defaultNamespaceDefinitions = $GLOBALS['TYPO3_CONF_VARS']['SYS']['fluid']['namespaces'];
         foreach ($defaultNamespaceDefinitions as $prefix => $registeredNameSpaces) {
@@ -124,7 +112,7 @@ class XsdGenerator
         }
         // no registered default prefix found, so build one from extension name part of the namespace
         // f.e. Vendor\MyExtension\Components => me (converting only the upper chars from 'MyExtension' to lower case
-        $nameSpaceParts = explode('\\', $namespace);
+        $nameSpaceParts = explode('\\', (string) $namespace);
         $lastFragment = $nameSpaceParts[1];
         return strtolower($this->strUpperChars($lastFragment));
     }
@@ -132,18 +120,16 @@ class XsdGenerator
     /**
      * generate xsd file for each component namespace
      *
-     * @param $path
-     * @param null $namespace
      * @return array Array of generated XML target namespaces
      */
-    public function generateXsd($path, $namespace = null)
+    public function generateXsd(string $path, string $namespace = null): array
     {
         $generatedNameSpaces = [];
         $namespaces = $this->componentLoader->getNamespaces();
         foreach ($namespaces as $registeredNamespace => $registeredNamepacePath) {
             if ($namespace === null || $registeredNamespace === $namespace) {
                 $components = $this->componentLoader->findComponentsInNamespace($registeredNamespace);
-                $filePath = rtrim($path, DIRECTORY_SEPARATOR) .
+                $filePath = rtrim((string) $path, DIRECTORY_SEPARATOR) .
                     DIRECTORY_SEPARATOR .
                     $this->getFileNameForNamespace($registeredNamespace);
                 file_put_contents($filePath, $this->generateXsdForNamespace($registeredNamespace, $components));
@@ -155,11 +141,8 @@ class XsdGenerator
 
     /**
      * returns a default filename for a given namespace
-     *
-     * @param $namespace
-     * @return string
      */
-    protected function getFileNameForNamespace($namespace)
+    protected function getFileNameForNamespace(string $namespace): string
     {
         return str_replace('\\', '_', $namespace) . '.xsd';
     }

--- a/Classes/Utility/ComponentArgumentConverter.php
+++ b/Classes/Utility/ComponentArgumentConverter.php
@@ -21,10 +21,8 @@ class ComponentArgumentConverter implements \TYPO3\CMS\Core\SingletonInterface
      * List of interfaces that provide conversion methods between scalar/compound
      * variable types and complex data structures,
      * e. g. transparently create a link model from a url string
-     *
-     * @var array
      */
-    protected $conversionInterfaces = [
+    protected array $conversionInterfaces = [
         'string' => [
             ConstructibleFromString::class,
             'fromString'
@@ -70,17 +68,13 @@ class ComponentArgumentConverter implements \TYPO3\CMS\Core\SingletonInterface
     /**
      * Registered argument type aliases
      * [alias => full php class name]
-     *
-     * @var array
      */
-    protected $typeAliases = [];
+    protected array $typeAliases = [];
 
     /**
      * Runtime cache to speed up conversion checks
-     *
-     * @var array
      */
-    protected $conversionCache = [];
+    protected array $conversionCache = [];
 
     public function __construct()
     {
@@ -93,11 +87,6 @@ class ComponentArgumentConverter implements \TYPO3\CMS\Core\SingletonInterface
 
     /**
      * Adds an interface to specify argument type conversion to list
-     *
-     * @param string $fromType
-     * @param string $interface
-     * @param string $constructor
-     * @return self
      */
     public function addConversionInterface(string $fromType, string $interface, string $constructor): self
     {
@@ -108,9 +97,6 @@ class ComponentArgumentConverter implements \TYPO3\CMS\Core\SingletonInterface
 
     /**
      * Removes an interface that specifies argument type conversion from list
-     *
-     * @param string $fromType
-     * @return self
      */
     public function removeConversionInterface(string $fromType): self
     {
@@ -121,10 +107,6 @@ class ComponentArgumentConverter implements \TYPO3\CMS\Core\SingletonInterface
 
     /**
      * Adds an alias for an argument type
-     *
-     * @param string $alias
-     * @param string $type
-     * @return self
      */
     public function addTypeAlias(string $alias, string $type): self
     {
@@ -134,9 +116,6 @@ class ComponentArgumentConverter implements \TYPO3\CMS\Core\SingletonInterface
 
     /**
      * Removes an alias for an argument type
-     *
-     * @param string $alias
-     * @return self
      */
     public function removeTypeAlias(string $alias): self
     {
@@ -164,8 +143,6 @@ class ComponentArgumentConverter implements \TYPO3\CMS\Core\SingletonInterface
      * Checks if a given variable type can be converted to another
      * data type by using alternative constructors in $this->conversionInterfaces
      *
-     * @param string $givenType
-     * @param string $toType
      * @return array             information about conversion or empty array
      */
     public function canTypeBeConvertedToType(string $givenType, string $toType): array
@@ -213,14 +190,10 @@ class ComponentArgumentConverter implements \TYPO3\CMS\Core\SingletonInterface
     /**
      * Tries to convert the specified value to the specified data type
      * by using alternative constructors in $this->conversionInterfaces
-     *
-     * @param mixed $value
-     * @param string $toType
-     * @return mixed
      */
-    public function convertValueToType($value, string $toType)
+    public function convertValueToType(mixed $value, string $toType): mixed
     {
-        $givenType = is_object($value) ? get_class($value) : gettype($value);
+        $givenType = is_object($value) ? $value::class : gettype($value);
 
         // Skip if the type can't be converted
         $conversionInfo = $this->canTypeBeConvertedToType($givenType, $toType);
@@ -244,13 +217,10 @@ class ComponentArgumentConverter implements \TYPO3\CMS\Core\SingletonInterface
 
     /**
      * Checks if the provided type describes a collection of values
-     *
-     * @param string $type
-     * @return boolean
      */
     protected function isCollectionType(string $type): bool
     {
-        return substr($type, -2) === '[]';
+        return str_ends_with($type, '[]');
     }
 
     /**
@@ -266,9 +236,6 @@ class ComponentArgumentConverter implements \TYPO3\CMS\Core\SingletonInterface
 
     /**
      * Checks if the given type is behaving like an array
-     *
-     * @param string $typeOrClassName
-     * @return boolean
      */
     protected function isAccessibleArray(string $typeOrClassName): bool
     {

--- a/Classes/Utility/ComponentLoader.php
+++ b/Classes/Utility/ComponentLoader.php
@@ -6,21 +6,14 @@ class ComponentLoader implements \TYPO3\CMS\Core\SingletonInterface
 {
     /**
      * Registered component namespaces
-     *
-     * @var array
      */
-    protected $namespaces = [];
+    protected array $namespaces = [];
 
     /**
      * Cache for class name => component file associations
-     *
-     * @var array
      */
-    protected $componentsCache = [];
+    protected array $componentsCache = [];
 
-    /**
-     * Initialize the component loader
-     */
     public function __construct()
     {
         $this->setNamespaces(
@@ -30,10 +23,6 @@ class ComponentLoader implements \TYPO3\CMS\Core\SingletonInterface
 
     /**
      * Adds a new component namespace
-     *
-     * @param string $namespace
-     * @param string $path
-     * @return self
      */
     public function addNamespace(string $namespace, string $path): self
     {
@@ -47,9 +36,6 @@ class ComponentLoader implements \TYPO3\CMS\Core\SingletonInterface
 
     /**
      * Removes a registered component namespace
-     *
-     * @param string $namespace
-     * @return self
      */
     public function removeNamespace(string $namespace): self
     {
@@ -59,9 +45,6 @@ class ComponentLoader implements \TYPO3\CMS\Core\SingletonInterface
 
     /**
      * Sets the component namespaces
-     *
-     * @param array $namespaces
-     * @return self
      */
     public function setNamespaces(array $namespaces): self
     {
@@ -79,8 +62,6 @@ class ComponentLoader implements \TYPO3\CMS\Core\SingletonInterface
 
     /**
      * Returns all registered component namespaces
-     *
-     * @return array
      */
     public function getNamespaces(): array
     {
@@ -89,12 +70,8 @@ class ComponentLoader implements \TYPO3\CMS\Core\SingletonInterface
 
     /**
      * Finds a component file based on its class namespace
-     *
-     * @param string $class
-     * @param string $ext
-     * @return string|null
      */
-    public function findComponent(string $class, string $ext = '.html')
+    public function findComponent(string $class, string $ext = '.html'): string|null
     {
         // Try cache first
         $cacheIdentifier = $class . '|' . $ext;
@@ -106,7 +83,7 @@ class ComponentLoader implements \TYPO3\CMS\Core\SingletonInterface
         $class = ltrim($class, '\\');
         foreach ($this->namespaces as $namespace => $path) {
             // No match, skip to next
-            if (strpos($class, $namespace . '\\') !== 0) {
+            if (!str_starts_with($class, $namespace . '\\')) {
                 continue;
             }
 
@@ -128,8 +105,6 @@ class ComponentLoader implements \TYPO3\CMS\Core\SingletonInterface
     /**
      * Provides a list of all components that are available in the specified component namespace
      *
-     * @param string $namespace
-     * @param string $ext
      * @return array  Array of components where the keys contain the component identifier (FQCN)
      *                and the values contain the path to the component
      */
@@ -150,10 +125,6 @@ class ComponentLoader implements \TYPO3\CMS\Core\SingletonInterface
 
     /**
      * Searches for component files in a directory and maps them to their namespace
-     *
-     * @param string $path
-     * @param string $ext
-     * @param string $namespace
      * @param array $scannedPaths  Collection of paths that have already been scanned for components;
      *                             this prevents infinite loops caused by circular symlinks
      * @return array
@@ -196,9 +167,6 @@ class ComponentLoader implements \TYPO3\CMS\Core\SingletonInterface
 
     /**
      * Sanitizes a PHP namespace for use in the component loader
-     *
-     * @param string $namespace
-     * @return string
      */
     protected function sanitizeNamespace(string $namespace): string
     {
@@ -207,9 +175,6 @@ class ComponentLoader implements \TYPO3\CMS\Core\SingletonInterface
 
     /**
      * Sanitizes a path for use in the component loader
-     *
-     * @param string $path
-     * @return string
      */
     protected function sanitizePath(string $path): string
     {

--- a/Classes/Utility/ComponentPrefixer/ComponentPrefixerInterface.php
+++ b/Classes/Utility/ComponentPrefixer/ComponentPrefixerInterface.php
@@ -6,16 +6,11 @@ interface ComponentPrefixerInterface extends \TYPO3\CMS\Core\SingletonInterface
 {
     /**
      * Returns the component prefix for the provided component namespaces
-     *
-     * @param string $namespace
-     * @return string
      */
     public function prefix(string $namespace): string;
 
     /**
      * Returns the separator to be used between prefix and the following string
-     *
-     * @return string
      */
     public function getSeparator(): string;
 }

--- a/Classes/Utility/ComponentPrefixer/GenericComponentPrefixer.php
+++ b/Classes/Utility/ComponentPrefixer/GenericComponentPrefixer.php
@@ -12,9 +12,6 @@ class GenericComponentPrefixer implements ComponentPrefixerInterface
      * example:
      *   namespace: \VENDOR\MyExtension\Components\Atom\MyComponent
      *   resulting prefix: vendorAtomMycomponent
-     *
-     * @param string $namespace
-     * @return string
      */
     public function prefix(string $namespace): string
     {
@@ -27,8 +24,6 @@ class GenericComponentPrefixer implements ComponentPrefixerInterface
 
     /**
      * Returns the separator to be used between prefix and the following string
-     *
-     * @return string
      */
     public function getSeparator(): string
     {

--- a/Classes/Utility/ComponentSettings.php
+++ b/Classes/Utility/ComponentSettings.php
@@ -8,31 +8,18 @@ class ComponentSettings implements \TYPO3\CMS\Core\SingletonInterface, \ArrayAcc
 {
     /**
      * Storage of the component settings
-     *
-     * @var array
      */
-    protected $settings = [];
+    protected array $settings = [];
 
-    /**
-     * @var TypoScriptService
-     */
-    protected TypoScriptService $typoScriptService;
-
-    /**
-     * @param TypoScriptService $typoScriptService
-     */
-    public function __construct(TypoScriptService $typoScriptService)
+    public function __construct(protected TypoScriptService $typoScriptService)
     {
-        $this->typoScriptService = $typoScriptService;
         $this->reset();
     }
 
     /**
      * Resets the settings to the default state (settings from ext_localconf.php and TypoScript)
-     *
-     * @return void
      */
-    public function reset()
+    public function reset(): void
     {
         $this->settings = array_merge(
             $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['settings'] ?? [],
@@ -44,20 +31,14 @@ class ComponentSettings implements \TYPO3\CMS\Core\SingletonInterface, \ArrayAcc
 
     /**
      * Checks if the specified settings path exists
-     *
-     * @param string $path
-     * @return bool
      */
-    public function exists(string $path)
+    public function exists(string $path): bool
     {
         return $this->get($path) !== null;
     }
 
     /**
      * Returns the value of the specified settings path
-     *
-     * @param string $path
-     * @return mixed
      */
     public function get(string $path)
     {
@@ -74,12 +55,8 @@ class ComponentSettings implements \TYPO3\CMS\Core\SingletonInterface, \ArrayAcc
 
     /**
      * Sets the value of the specified settings path
-     *
-     * @param string $path
-     * @param mixed $value
-     * @return self
      */
-    public function set(string $path, $value)
+    public function set(string $path, mixed $value): self
     {
         $path = explode('.', $path);
         $variable =& $this->settings;
@@ -95,11 +72,8 @@ class ComponentSettings implements \TYPO3\CMS\Core\SingletonInterface, \ArrayAcc
 
     /**
      * Unsets the specified settings path
-     *
-     * @param string $path
-     * @return self
      */
-    public function unset(string $path)
+    public function unset(string $path): self
     {
         $this->set($path, null);
         return $this;
@@ -107,49 +81,36 @@ class ComponentSettings implements \TYPO3\CMS\Core\SingletonInterface, \ArrayAcc
 
     /**
      * Checks if a subsetting exists; Part of the ArrayAccess implementation
-     *
-     * @param string $offset
-     * @return bool
      */
     #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->settings[$offset]);
     }
 
     /**
      * Returns the value of a subsetting; Part of the ArrayAccess implementation
-     *
-     * @param string $offset
-     * @return mixed
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->settings[$offset];
     }
 
     /**
      * Sets the value of a subsetting; Part of the ArrayAccess implementation
-     *
-     * @param string $offset
-     * @param mixed $value
-     * @return void
      */
     #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         $this->settings[$offset] = $value;
     }
 
     /**
      * Unsets a subsetting; Part of the ArrayAccess implementation
-     *
-     * @param string $offset
-     * @return void
      */
     #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->settings[$offset]);
     }

--- a/Classes/ViewHelpers/ComponentViewHelper.php
+++ b/Classes/ViewHelpers/ComponentViewHelper.php
@@ -7,24 +7,15 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 class ComponentViewHelper extends AbstractViewHelper
 {
-    /**
-     * @var boolean
-     */
     protected $escapeOutput = false;
 
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('description', 'string', 'Description of the component');
     }
 
-    /*
-     * @param array $arguments
-     * @param \Closure $renderChildrenClosure
-     * @param RenderingContextInterface $renderingContext
-     * @return string
-     */
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
-        return trim($renderChildrenClosure());
+        return trim((string) $renderChildrenClosure());
     }
 }

--- a/Classes/ViewHelpers/ContentViewHelper.php
+++ b/Classes/ViewHelpers/ContentViewHelper.php
@@ -12,7 +12,7 @@ class ContentViewHelper extends AbstractViewHelper
 
     protected $escapeChildren = true;
 
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('slot', 'string', 'Slot name', false, ComponentRenderer::DEFAULT_SLOT);
     }

--- a/Classes/ViewHelpers/Form/FieldInformationViewHelper.php
+++ b/Classes/ViewHelpers/Form/FieldInformationViewHelper.php
@@ -46,9 +46,6 @@ use TYPO3\CMS\Form\ViewHelpers\RenderRenderableViewHelper;
  */
 class FieldInformationViewHelper extends AbstractFormFieldViewHelper
 {
-    /**
-     * @var bool
-     */
     protected $escapeOutput = false;
 
     public function initializeArguments(): void
@@ -65,10 +62,8 @@ class FieldInformationViewHelper extends AbstractFormFieldViewHelper
 
     /**
      * Provides information about the form field to the child elements of this ViewHelper
-     *
-     * @return string
      */
-    public function render()
+    public function render(): string
     {
         // Get form context if available
         $formRuntime = $this->renderingContext
@@ -94,11 +89,9 @@ class FieldInformationViewHelper extends AbstractFormFieldViewHelper
     }
 
     /**
-     * returns prefix / namespace
-     *
      * @return string prefix/namespace
      */
-    protected function getPrefix()
+    protected function getPrefix(): string
     {
         if (!$this->viewHelperVariableContainer->exists(\TYPO3\CMS\Fluid\ViewHelpers\FormViewHelper::class, 'fieldNamePrefix')) {
             return '';

--- a/Classes/ViewHelpers/Form/TranslatedValidationResultsViewHelper.php
+++ b/Classes/ViewHelpers/Form/TranslatedValidationResultsViewHelper.php
@@ -1,6 +1,7 @@
 <?php
 namespace SMS\FluidComponents\ViewHelpers\Form;
 
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Error\Message;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use TYPO3\CMS\Form\Domain\Model\Renderable\RootRenderableInterface;
@@ -71,9 +72,8 @@ class TranslatedValidationResultsViewHelper extends AbstractViewHelper
         RenderingContextInterface $renderingContext
     ) {
         $templateVariableContainer = $renderingContext->getVariableProvider();
-        $controllerContext = $renderingContext->getControllerContext();
 
-        $extensionName = $arguments['extensionName'] ?? $controllerContext->getRequest()->getControllerExtensionName();
+        $extensionName = $arguments['extensionName'] ?? $renderingContext->getRequest()->getControllerExtensionName();
         $for = rtrim($arguments['for'], '.');
         $element = $arguments['element'];
 
@@ -100,7 +100,7 @@ class TranslatedValidationResultsViewHelper extends AbstractViewHelper
         }
 
         // Fetch validation results from API
-        $validationResults = $controllerContext->getRequest()->getOriginalRequestMappingResults();
+        $validationResults = $renderingContext->getRequest()->getOriginalRequestMappingResults();
         if ($validationResults !== null && $for !== '') {
             $validationResults = $validationResults->forProperty($for);
         }
@@ -287,7 +287,7 @@ class TranslatedValidationResultsViewHelper extends AbstractViewHelper
             ->getViewHelperVariableContainer()
             ->get(RenderRenderableViewHelper::class, 'formRuntime');
 
-        return TranslationService::getInstance()->translateFormElementError(
+        return GeneralUtility::makeInstance(TranslationService::class)->translateFormElementError(
             $element,
             $code,
             $arguments,

--- a/Classes/ViewHelpers/Form/TranslatedValidationResultsViewHelper.php
+++ b/Classes/ViewHelpers/Form/TranslatedValidationResultsViewHelper.php
@@ -230,13 +230,17 @@ class TranslatedValidationResultsViewHelper extends AbstractViewHelper
         string $languageKey = null,
         array $alternativeLanguageKeys = null
     ): ?string {
+        if ($languageKey) {
+            $localeFactory = GeneralUtility::makeInstance(Locales::class);
+            $locale = $localeFactory->createLocale($languageKey, $alternativeLanguageKeys);
+        }
+
         foreach ($translationChain as $translatePrefix) {
             $translatedMessage = LocalizationUtility::translate(
                 $translatePrefix . $code,
                 $extensionName,
                 $arguments,
-                $languageKey,
-                $alternativeLanguageKeys
+                $locale ?? null,
             );
             if ($translatedMessage) {
                 return $translatedMessage;

--- a/Classes/ViewHelpers/Form/TranslatedValidationResultsViewHelper.php
+++ b/Classes/ViewHelpers/Form/TranslatedValidationResultsViewHelper.php
@@ -50,6 +50,7 @@ class TranslatedValidationResultsViewHelper extends AbstractViewHelper
         $this->registerArgument('element', RootRenderableInterface::class, 'Form Element to translate');
         $this->registerArgument('extensionName', 'string', 'UpperCamelCased extension key (for example BlogExample)');
         $this->registerArgument('languageKey', 'string', 'Language key ("dk" for example) or "default" to use for this translation. If this argument is empty, we use the current language');
+        // @deprecated will be removed in 4.0
         $this->registerArgument('alternativeLanguageKeys', 'array', 'Alternative language keys if no translation does exist');
     }
 
@@ -218,7 +219,7 @@ class TranslatedValidationResultsViewHelper extends AbstractViewHelper
      * @param string $defaultValue Default validation message used as a fallback
      * @param string|null $extensionName The name of the extension
      * @param string $languageKey The language key or null for using the current language from the system
-     * @param string[] $alternativeLanguageKeys The alternative language keys if no translation was found. If null and we are in the frontend, then the language_alt from TypoScript setup will be used
+     * @param string[] $alternativeLanguageKeys The alternative language keys if no translation was found. If null and we are in the frontend, then the language_alt from TypoScript setup will be used. @deprecated will be removed in 4.0
      * @return string|null The value from LOCAL_LANG or null if no translation was found.
      */
     public static function translateValidationError(
@@ -230,6 +231,9 @@ class TranslatedValidationResultsViewHelper extends AbstractViewHelper
         string $languageKey = null,
         array $alternativeLanguageKeys = null
     ): ?string {
+        if ($alternativeLanguageKeys) {
+            trigger_error('Calling translatedValidationResults with the argument $alternativeLanguageKeys will be removed in fluid-components 4.0', E_USER_DEPRECATED);
+        }
         if ($languageKey) {
             $localeFactory = GeneralUtility::makeInstance(Locales::class);
             $locale = $localeFactory->createLocale($languageKey, $alternativeLanguageKeys);

--- a/Classes/ViewHelpers/Form/TranslatedValidationResultsViewHelper.php
+++ b/Classes/ViewHelpers/Form/TranslatedValidationResultsViewHelper.php
@@ -37,14 +37,9 @@ class TranslatedValidationResultsViewHelper extends AbstractViewHelper
 
     /**
      * Stores message objects that have already been translated
-     *
-     * @var array
      */
-    protected static $translatedMessagesCache = [];
+    protected static array $translatedMessagesCache = [];
 
-    /**
-     * @var bool
-     */
     protected $escapeOutput = false;
 
     public function initializeArguments(): void
@@ -60,21 +55,16 @@ class TranslatedValidationResultsViewHelper extends AbstractViewHelper
 
     /**
      * Provides and translates validation results for the specified form field
-     *
-     * @param array $arguments
-     * @param \Closure $renderChildrenClosure
-     * @param RenderingContextInterface $renderingContext
-     * @return mixed
      */
     public static function renderStatic(
         array $arguments,
         \Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext
-    ) {
+    ): mixed {
         $templateVariableContainer = $renderingContext->getVariableProvider();
 
         $extensionName = $arguments['extensionName'] ?? $renderingContext->getRequest()->getControllerExtensionName();
-        $for = rtrim($arguments['for'], '.');
+        $for = rtrim((string) $arguments['for'], '.');
         $element = $arguments['element'];
 
         $translatedResults = [
@@ -95,7 +85,7 @@ class TranslatedValidationResultsViewHelper extends AbstractViewHelper
             $translatePrefix = '';
         } else {
             // Generate static language prefix for validation translations outsite of EXT:form
-            $translatePrefix = ($arguments['translatePrefix']) ? rtrim($arguments['translatePrefix'], '.') . '.' : '';
+            $translatePrefix = ($arguments['translatePrefix']) ? rtrim((string) $arguments['translatePrefix'], '.') . '.' : '';
             $translatePrefix .= ($for) ? $for . '.' : '';
         }
 
@@ -165,15 +155,6 @@ class TranslatedValidationResultsViewHelper extends AbstractViewHelper
     /**
      * Translates a validation message, either by using EXT:form's translation chain
      * or by the custom implementation of fluid_components for validation translations
-     *
-     * @param RenderingContextInterface $renderingContext
-     * @param Message $message
-     * @param string $translatePrefix
-     * @param RootRenderableInterface $element
-     * @param string $extensionName
-     * @param string $languageKey
-     * @param array $alternativeLanguageKeys
-     * @return void
      */
     protected static function translateMessage(
         RenderingContextInterface $renderingContext,
@@ -213,7 +194,7 @@ class TranslatedValidationResultsViewHelper extends AbstractViewHelper
         }
 
         // Create new message object from the translated message
-        $messageClass = get_class($message);
+        $messageClass = $message::class;
         $newMessage = new $messageClass(
             $translatedMessage,
             $message->getCode(),
@@ -267,12 +248,6 @@ class TranslatedValidationResultsViewHelper extends AbstractViewHelper
     /**
      * Translates the provided validation message by using the translation chain by EXT:form
      *
-     * @param RenderingContextInterface $renderingContext
-     * @param RootRenderableInterface $element
-     * @param int $code
-     * @param string $defaultValue
-     * @param array $arguments
-     * @return string
      * @throws \InvalidArgumentException
      */
     public static function translateFormElementError(

--- a/Classes/ViewHelpers/ParamViewHelper.php
+++ b/Classes/ViewHelpers/ParamViewHelper.php
@@ -9,7 +9,7 @@ class ParamViewHelper extends AbstractViewHelper
 {
     use ParserRuntimeOnly;
 
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('name', 'string', 'Parameter name', true);
         $this->registerArgument('type', 'string', 'Parameter type', true);

--- a/Classes/ViewHelpers/RendererViewHelper.php
+++ b/Classes/ViewHelpers/RendererViewHelper.php
@@ -7,18 +7,9 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 class RendererViewHelper extends AbstractViewHelper
 {
-    /**
-     * @var boolean
-     */
     protected $escapeOutput = false;
 
-    /*
-     * @param array $arguments
-     * @param \Closure $renderChildrenClosure
-     * @param RenderingContextInterface $renderingContext
-     * @return string
-     */
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
     {
         return $renderChildrenClosure();
     }

--- a/Classes/ViewHelpers/SlotViewHelper.php
+++ b/Classes/ViewHelpers/SlotViewHelper.php
@@ -9,12 +9,9 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 class SlotViewHelper extends AbstractViewHelper
 {
-    /**
-     * @var boolean
-     */
     protected $escapeOutput = false;
 
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('name', 'string', 'Name of the slot that should be rendered', false, 'content');
         $this->registerArgument(
@@ -27,12 +24,6 @@ class SlotViewHelper extends AbstractViewHelper
         );
     }
 
-    /*
-     * @param array $arguments
-     * @param \Closure $renderChildrenClosure
-     * @param RenderingContextInterface $renderingContext
-     * @return string
-     */
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
         $slotContent = $renderingContext->getVariableProvider()->get($arguments['name']);

--- a/Classes/ViewHelpers/Translate/LabelsViewHelper.php
+++ b/Classes/ViewHelpers/Translate/LabelsViewHelper.php
@@ -19,6 +19,7 @@ class LabelsViewHelper extends AbstractViewHelper
         $this->registerArgument('keys', 'array', 'Array of translation keys; Can also contain subarrays, then "key" is key, "arguments" is an array of sprintf arguments, and "default" is a default value', true);
         $this->registerArgument('extensionName', 'string', 'UpperCamelCased extension key (for example BlogExample)');
         $this->registerArgument('languageKey', 'string', 'Language key ("dk" for example) or "default" to use for this translation. If this argument is empty, we use the current language');
+        // @deprecated will be removed in 4.0
         $this->registerArgument('alternativeLanguageKeys', 'array', 'Alternative language keys if no translation does exist');
     }
 
@@ -75,6 +76,9 @@ class LabelsViewHelper extends AbstractViewHelper
      */
     protected static function translate($id, $extensionName, $arguments, $languageKey, $alternativeLanguageKeys)
     {
+        if ($alternativeLanguageKeys) {
+            trigger_error('Calling labels with the argument $alternativeLanguageKeys will be removed in fluid-components 4.0', E_USER_DEPRECATED);
+        }
         if ($languageKey) {
             $localeFactory = GeneralUtility::makeInstance(Locales::class);
             $locale = $localeFactory->createLocale($languageKey, $alternativeLanguageKeys);

--- a/Classes/ViewHelpers/Translate/LabelsViewHelper.php
+++ b/Classes/ViewHelpers/Translate/LabelsViewHelper.php
@@ -3,7 +3,6 @@
 namespace SMS\FluidComponents\ViewHelpers\Translate;
 
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
-use TYPO3\CMS\Fluid\Core\ViewHelper\Exception\InvalidVariableException;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
@@ -27,7 +26,7 @@ class LabelsViewHelper extends AbstractViewHelper
         array $arguments,
         \Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext
-    ): string {
+    ): array {
         $keys = $arguments['keys'];
         $extensionName = $arguments['extensionName'];
 
@@ -76,6 +75,11 @@ class LabelsViewHelper extends AbstractViewHelper
      */
     protected static function translate($id, $extensionName, $arguments, $languageKey, $alternativeLanguageKeys)
     {
-        return LocalizationUtility::translate($id, $extensionName, $arguments, $languageKey, $alternativeLanguageKeys);
+        if ($languageKey) {
+            $localeFactory = GeneralUtility::makeInstance(Locales::class);
+            $locale = $localeFactory->createLocale($languageKey, $alternativeLanguageKeys);
+        }
+
+        return LocalizationUtility::translate($id, $extensionName, $arguments, $locale ?? null);
     }
 }

--- a/Classes/ViewHelpers/Translate/LabelsViewHelper.php
+++ b/Classes/ViewHelpers/Translate/LabelsViewHelper.php
@@ -13,11 +13,9 @@ class LabelsViewHelper extends AbstractViewHelper
     use CompileWithRenderStatic;
 
     /**
-     * Initialize arguments.
-     *
      * @throws \TYPO3Fluid\Fluid\Core\ViewHelper\Exception
      */
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('keys', 'array', 'Array of translation keys; Can also contain subarrays, then "key" is key, "arguments" is an array of sprintf arguments, and "default" is a default value', true);
         $this->registerArgument('extensionName', 'string', 'UpperCamelCased extension key (for example BlogExample)');
@@ -25,19 +23,16 @@ class LabelsViewHelper extends AbstractViewHelper
         $this->registerArgument('alternativeLanguageKeys', 'array', 'Alternative language keys if no translation does exist');
     }
 
-    /*
-     * @param array $arguments
-     * @param \Closure $renderChildrenClosure
-     * @param RenderingContextInterface $renderingContext
-     * @return string
-     */
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
-    {
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ): string {
         $keys = $arguments['keys'];
         $extensionName = $arguments['extensionName'];
 
         $request = $renderingContext->getRequest();
-        $extensionName = $extensionName ?? $request->getControllerExtensionName();
+        $extensionName ??= $request->getControllerExtensionName();
 
         $labels = [];
         foreach ($keys as $name => $translation) {
@@ -52,7 +47,7 @@ class LabelsViewHelper extends AbstractViewHelper
 
             try {
                 $value = static::translate($translation, $extensionName, $translateArguments, $arguments['languageKey'], $arguments['alternativeLanguageKeys']);
-            } catch (\InvalidArgumentException $e) {
+            } catch (\InvalidArgumentException) {
                 $value = null;
             }
             if ($value === null) {

--- a/Classes/ViewHelpers/Translate/LabelsViewHelper.php
+++ b/Classes/ViewHelpers/Translate/LabelsViewHelper.php
@@ -36,7 +36,7 @@ class LabelsViewHelper extends AbstractViewHelper
         $keys = $arguments['keys'];
         $extensionName = $arguments['extensionName'];
 
-        $request = $renderingContext->getControllerContext()->getRequest();
+        $request = $renderingContext->getRequest();
         $extensionName = $extensionName ?? $request->getControllerExtensionName();
 
         $labels = [];

--- a/Classes/ViewHelpers/Variable/MapViewHelper.php
+++ b/Classes/ViewHelpers/Variable/MapViewHelper.php
@@ -28,17 +28,9 @@ class MapViewHelper extends AbstractViewHelper
 {
     use CompileWithRenderStatic;
 
-    /**
-     * @var bool
-     */
     protected $escapeOutput = false;
 
-    /**
-     * Initialize arguments
-     *
-     * @api
-     */
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         parent::initializeArguments();
         $this->registerArgument('fieldMapping', 'array', 'Map of fields keys.');
@@ -47,9 +39,6 @@ class MapViewHelper extends AbstractViewHelper
     }
 
     /**
-     * @param mixed $subject
-     * @param \Closure $renderChildrenClosure
-     * @param RenderingContextInterface $renderingContext
      * @return array remapped array
      */
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
@@ -58,7 +47,7 @@ class MapViewHelper extends AbstractViewHelper
         $mapKeyArray = $arguments['fieldMapping'] ?? [];
         $keepFields = $arguments['keepFields'] ?? [];
         if (!is_array($keepFields)) {
-            $keepFields = array_map('trim', explode(',', $keepFields));
+            $keepFields = array_map('trim', explode(',', (string) $keepFields));
         }
 
         $newArray = [];

--- a/Classes/ViewHelpers/Variable/PushViewHelper.php
+++ b/Classes/ViewHelpers/Variable/PushViewHelper.php
@@ -23,27 +23,18 @@ class PushViewHelper extends AbstractViewHelper
 {
     use CompileWithContentArgumentAndRenderStatic;
 
-    /**
-     * @return void
-     */
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('item', 'mixed', 'Item to push to specified array variable. If not in arguments then taken from tag content');
         $this->registerArgument('name', 'string', 'Name of variable to extend', true);
         $this->registerArgument('key', 'string', 'Key that should be used in the array');
     }
 
-    /**
-     * @param array $arguments
-     * @param \Closure $renderChildrenClosure
-     * @param RenderingContextInterface $renderingContext
-     * @return null
-     */
     public static function renderStatic(
         array $arguments,
         \Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext
-    ) {
+    ): void {
         $value = $arguments['item'] ?? $renderChildrenClosure();
 
         $variable = $renderingContext->getVariableProvider()->get($arguments['name']);

--- a/Tests/Functional/ComponentRendererTest.php
+++ b/Tests/Functional/ComponentRendererTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace SMS\FluidComponents\Tests\Functional;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use SMS\FluidComponents\Fluid\ViewHelper\ComponentRenderer;
 use TYPO3\CMS\Core\Cache\Backend\NullBackend;
 use TYPO3\CMS\Core\Http\ServerRequest;
@@ -37,7 +39,7 @@ class ComponentRendererTest extends FunctionalTestCase
         // Register test components
         $this->componentNamespaces = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['namespaces'] ?? null;
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['namespaces'] = [
-            $this->testNamespace => realpath(dirname(__FILE__) . '/../Fixtures/Functional/Components/')
+            $this->testNamespace => realpath(__DIR__ . '/../Fixtures/Functional/Components/')
         ];
 
         // Register and then disable fluid cache
@@ -47,7 +49,7 @@ class ComponentRendererTest extends FunctionalTestCase
         $cacheManager->registerCache(new $cacheClass('fluid_template', new NullBackend(null)));
     }
 
-    public function renderComponentProvider()
+    public static function renderComponentProvider()
     {
         return [
             ['WithoutParameters', [], '', 'Just a renderer.'],
@@ -63,11 +65,9 @@ class ComponentRendererTest extends FunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderComponentProvider
-     */
-    public function renderComponent($component, $arguments, $content, $expected)
+    #[Test]
+    #[DataProvider('renderComponentProvider')]
+    public function renderComponent($component, $arguments, $content, $expected): void
     {
         $container = $this->getContainer();
 
@@ -94,13 +94,11 @@ class ComponentRendererTest extends FunctionalTestCase
             $renderer,
             $arguments,
             $renderingContext,
-            function () use ($content) {
-                return $content;
-            }
+            fn() => $content
         );
 
         // Ignore whitespace output from components
-        $output = trim($output);
+        $output = trim((string) $output);
 
         $this->assertEquals($expected, $output);
     }

--- a/Tests/Functional/ParameterEscapingTest.php
+++ b/Tests/Functional/ParameterEscapingTest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace SMS\FluidComponents\Tests\Functional;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use SMS\FluidComponents\Utility\ComponentLoader;
 use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
 use TYPO3\CMS\Extbase\Mvc\Request;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use SMS\FluidComponents\Utility\ComponentLoader;
 use TYPO3\CMS\Fluid\View\TemplateView;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
@@ -26,11 +28,11 @@ class ParameterEscapingTest extends FunctionalTestCase
         $componentLoader = GeneralUtility::makeInstance(ComponentLoader::class);
         $componentLoader->addNamespace(
             'SMS\\FluidComponents\\Tests\\Fixtures\\Functional\\Components',
-            realpath(dirname(__FILE__) . '/../Fixtures/Functional/Components/')
+            realpath(__DIR__ . '/../Fixtures/Functional/Components/')
         );
     }
 
-    public function renderDataProvider(): \Generator
+    public static function renderDataProvider(): \Generator
     {
         // {content} in component [escape=true]
         yield [
@@ -187,10 +189,8 @@ class ParameterEscapingTest extends FunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[Test]
+    #[DataProvider('renderDataProvider')]
     public function render(string $template, string $expected): void
     {
         $view = new TemplateView();

--- a/Tests/Functional/SlotParameterTest.php
+++ b/Tests/Functional/SlotParameterTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace SMS\FluidComponents\Tests\Functional;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use SMS\FluidComponents\Exception\InvalidArgumentException;
 use SMS\FluidComponents\Utility\ComponentLoader;
 use TYPO3\CMS\Core\Http\ServerRequest;
@@ -27,11 +29,11 @@ class SlotParameterTest extends FunctionalTestCase
         $componentLoader = GeneralUtility::makeInstance(ComponentLoader::class);
         $componentLoader->addNamespace(
             'SMS\\FluidComponents\\Tests\\Fixtures\\Functional\\Components',
-            realpath(dirname(__FILE__) . '/../Fixtures/Functional/Components/')
+            realpath(__DIR__ . '/../Fixtures/Functional/Components/')
         );
     }
 
-    public function renderDataProvider(): \Generator
+    public static function renderDataProvider(): \Generator
     {
         // Check override order of slot content
         yield 'parameter, named slot and tag content provided' => [
@@ -112,10 +114,8 @@ class SlotParameterTest extends FunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[Test]
+    #[DataProvider('renderDataProvider')]
     public function render(string $template, string $expected): void
     {
         $view = new TemplateView();
@@ -138,9 +138,7 @@ class SlotParameterTest extends FunctionalTestCase
         self::assertSame($expected, $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function unspecifiedRequiredSlot(): void
     {
         $template = '<test:slotParameter />';
@@ -169,9 +167,7 @@ class SlotParameterTest extends FunctionalTestCase
         $view->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function undefinedSlot(): void
     {
         $template = '<test:slotParameter><fc:content slot="slot">content</fc:content><fc:content slot="invalidSlot">more content</fc:content></test:slotParameter>';

--- a/Tests/Functional/ViewHelpers/Variable/MapViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/Variable/MapViewHelperTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace SMS\FluidComponents\Tests\Functional\ViewHelpers\Variable;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Fluid\View\TemplateView;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
@@ -14,7 +16,7 @@ class MapViewHelperTest extends FunctionalTestCase
         'typo3conf/ext/fluid_components'
     ];
 
-    public function renderDataProvider(): \Generator
+    public static function renderDataProvider(): \Generator
     {
         $input = [
             0 => [
@@ -123,10 +125,8 @@ class MapViewHelperTest extends FunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[Test]
+    #[DataProvider('renderDataProvider')]
     public function render(array $input, string $template, array $expected): void
     {
         $view = new TemplateView();

--- a/Tests/Functional/ViewHelpers/Variable/PushViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/Variable/PushViewHelperTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace SMS\FluidComponents\Tests\Functional\ViewHelpers\Variable;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Fluid\View\TemplateView;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
@@ -14,7 +16,7 @@ class PushViewHelperTest extends FunctionalTestCase
         'typo3conf/ext/fluid_components'
     ];
 
-    public function renderDataProvider(): \Generator
+    public static function renderDataProvider(): \Generator
     {
         $simpleArray = ['a', 'b', 'c', 'd'];
         $arrayWithKeys = ['keyA' => 'a', 'keyB' => 'b', 'keyC' => 'c', 'keyD' => 'd'];
@@ -45,10 +47,8 @@ class PushViewHelperTest extends FunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[Test]
+    #[DataProvider('renderDataProvider')]
     public function render(array $input, string $template, array $expected): void
     {
         $view = new TemplateView();

--- a/Tests/Helpers/ComponentArgumentConverter/DummyValue.php
+++ b/Tests/Helpers/ComponentArgumentConverter/DummyValue.php
@@ -10,11 +10,13 @@ class DummyValue implements DummyConversionInterface, BaseObjectConversionInterf
         $this->value = $value;
     }
 
+    #[\Override]
     public static function fromString(string $value)
     {
         return new static($value);
     }
 
+    #[\Override]
     public static function fromBaseObject(BaseObject $object)
     {
         return new static($object->value);

--- a/Tests/Unit/Domain/Model/DateTimeTest.php
+++ b/Tests/Unit/Domain/Model/DateTimeTest.php
@@ -2,11 +2,15 @@
 
 namespace SMS\FluidComponents\Tests\Unit\Domain\Model;
 
-use SMS\FluidComponents\Utility\ComponentArgumentConverter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use SMS\FluidComponents\Domain\Model\DateTime;
+use SMS\FluidComponents\Utility\ComponentArgumentConverter;
 
 class DateTimeTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
 {
+    protected ComponentArgumentConverter $converter;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -14,7 +18,7 @@ class DateTimeTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
         $this->converter = new ComponentArgumentConverter();
     }
 
-    public function convertToDateTimeProvider()
+    public static function convertToDateTimeProvider()
     {
         return [
             [new \DateTime('tomorrow'), new DateTime('tomorrow')],
@@ -24,11 +28,9 @@ class DateTimeTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider convertToDateTimeProvider
-     */
-    public function convertToDateTime($value, $expected)
+    #[Test]
+    #[DataProvider('convertToDateTimeProvider')]
+    public function convertToDateTime($value, $expected): void
     {
         $result = $this->converter->convertValueToType($value, DateTime::class);
         $this->assertEquals($expected, $result);

--- a/Tests/Unit/Domain/Model/LabelsTest.php
+++ b/Tests/Unit/Domain/Model/LabelsTest.php
@@ -2,6 +2,7 @@
 
 namespace SMS\FluidComponents\Tests\Unit\Domain\Model;
 
+use PHPUnit\Framework\Attributes\Test;
 use SMS\FluidComponents\Domain\Model\Labels;
 
 class LabelsTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
@@ -11,7 +12,7 @@ class LabelsTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
         parent::setUp();
 
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['namespaces'] = [
-            'SMS\FluidComponents\Tests' => realpath(dirname(__FILE__) . '/../../../Fixtures/Unit/ComponentLoader')
+            'SMS\FluidComponents\Tests' => realpath(__DIR__ . '/../../../Fixtures/Unit/ComponentLoader')
         ];
     }
 
@@ -21,29 +22,22 @@ class LabelsTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
     //     $labels->setComponentNamespace('SMS\FluidComponents\Tests\Example');
     //     $this->assertEquals('Test value', $labels['testlabel']);
     // }
-
-    /**
-     * @test
-     */
-    public function overrideLabelsWithConstructor()
+    #[Test]
+    public function overrideLabelsWithConstructor(): void
     {
         $labels = new Labels(['testlabel' => 'Override value']);
         $this->assertEquals('Override value', $labels['testlabel']);
     }
 
-    /**
-     * @test
-     */
-    public function overrideLabelsWithArrayConstructor()
+    #[Test]
+    public function overrideLabelsWithArrayConstructor(): void
     {
         $labels = Labels::fromArray(['testlabel' => 'Override value']);
         $this->assertEquals('Override value', $labels['testlabel']);
     }
 
-    /**
-     * @test
-     */
-    public function overrideLabelsWithArrayAccess()
+    #[Test]
+    public function overrideLabelsWithArrayAccess(): void
     {
         $labels = new Labels;
         $labels['testlabel'] = 'New override value';

--- a/Tests/Unit/Domain/Model/LinkTest.php
+++ b/Tests/Unit/Domain/Model/LinkTest.php
@@ -2,11 +2,15 @@
 
 namespace SMS\FluidComponents\Tests\Unit\Domain\Model;
 
-use SMS\FluidComponents\Utility\ComponentArgumentConverter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use SMS\FluidComponents\Domain\Model\Link;
+use SMS\FluidComponents\Utility\ComponentArgumentConverter;
 
 class LinkTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
 {
+    protected ComponentArgumentConverter $converter;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -14,25 +18,21 @@ class LinkTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
         $this->converter = new ComponentArgumentConverter();
     }
 
-    /**
-     * @test
-     */
-    public function convertStringToLink()
+    #[Test]
+    public function convertStringToLink(): void
     {
         $result = $this->converter->convertValueToType('https://example.com', Link::class);
         $this->assertEquals(new Link('https://example.com'), $result);
     }
 
-    /**
-     * @test
-     */
-    public function convertEmptyStringToLink()
+    #[Test]
+    public function convertEmptyStringToLink(): void
     {
         $result = $this->converter->convertValueToType('', Link::class);
         $this->assertEquals(null, $result);
     }
 
-    public function linkPropertiesProvider()
+    public static function linkPropertiesProvider()
     {
         return [
             [
@@ -60,11 +60,9 @@ class LinkTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider linkPropertiesProvider
-     */
-    public function linkProperties($uri, $scheme, $user, $password, $host, $port, $path, $query, $fragment)
+    #[Test]
+    #[DataProvider('linkPropertiesProvider')]
+    public function linkProperties($uri, $scheme, $user, $password, $host, $port, $path, $query, $fragment): void
     {
         $result = $this->converter->convertValueToType($uri, Link::class);
         $this->assertEquals($uri, $result->getUri());

--- a/Tests/Unit/Service/XsdGeneratorTest.php
+++ b/Tests/Unit/Service/XsdGeneratorTest.php
@@ -2,6 +2,7 @@
 
 namespace SMS\FluidComponents\Tests\Unit\Service;
 
+use PHPUnit\Framework\Attributes\Test;
 use SMS\FluidComponents\Service\XsdGenerator;
 use SMS\FluidComponents\Utility\ComponentLoader;
 
@@ -35,7 +36,7 @@ class XsdGeneratorTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
      */
     public function invokeMethod(&$object, $methodName, array $parameters = [])
     {
-        $reflection = new \ReflectionClass(get_class($object));
+        $reflection = new \ReflectionClass($object::class);
         $method = $reflection->getMethod($methodName);
         $method->setAccessible(true);
 
@@ -44,10 +45,10 @@ class XsdGeneratorTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
 
 
     /**
-     * @test
      * @throws \ReflectionException
      */
-    public function getFileNameForNamespace() {
+    #[Test]
+    public function getFileNameForNamespace(): void {
 
         $this->assertEquals(
             'SMS_FluidComponents_Components.xsd',
@@ -56,10 +57,10 @@ class XsdGeneratorTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
     }
 
     /**
-     * @test
      * @throws \ReflectionException
      */
-    public function getDefaultPrefixForNamespace() {
+    #[Test]
+    public function getDefaultPrefixForNamespace(): void {
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['fluid']['namespaces']['fc'][] = 'SMS\FluidComponents\ViewHelpers';
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['fluid']['namespaces']['ab'][] = 'SMS\OtherComponents\Components';
         $this->assertEquals(

--- a/Tests/Unit/Utility/ComponentArgumentConverterTest.php
+++ b/Tests/Unit/Utility/ComponentArgumentConverterTest.php
@@ -2,13 +2,14 @@
 
 namespace SMS\FluidComponents\Tests\Unit\Utility;
 
+use PHPUnit\Framework\Attributes\Test;
 use SMS\FluidComponents\Interfaces\ConstructibleFromArray;
-use SMS\FluidComponents\Utility\ComponentArgumentConverter;
 use SMS\FluidComponents\Tests\Helpers\ComponentArgumentConverter\BaseObject;
+use SMS\FluidComponents\Tests\Helpers\ComponentArgumentConverter\BaseObjectConversionInterface;
+use SMS\FluidComponents\Tests\Helpers\ComponentArgumentConverter\DummyConversionInterface;
 use SMS\FluidComponents\Tests\Helpers\ComponentArgumentConverter\DummyValue;
 use SMS\FluidComponents\Tests\Helpers\ComponentArgumentConverter\SpecificObject;
-use SMS\FluidComponents\Tests\Helpers\ComponentArgumentConverter\DummyConversionInterface;
-use SMS\FluidComponents\Tests\Helpers\ComponentArgumentConverter\BaseObjectConversionInterface;
+use SMS\FluidComponents\Utility\ComponentArgumentConverter;
 
 class ComponentArgumentConverterTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
 {
@@ -21,10 +22,8 @@ class ComponentArgumentConverterTest extends \TYPO3\TestingFramework\Core\Unit\U
         $this->converter = new ComponentArgumentConverter();
     }
 
-    /**
-     * @test
-     */
-    public function addTypeAlias()
+    #[Test]
+    public function addTypeAlias(): void
     {
         $this->converter->addTypeAlias('Alias', '\Vendor\Original');
 
@@ -34,10 +33,8 @@ class ComponentArgumentConverterTest extends \TYPO3\TestingFramework\Core\Unit\U
         );
     }
 
-    /**
-     * @test
-     */
-    public function removeTypeAlias()
+    #[Test]
+    public function removeTypeAlias(): void
     {
         $this->converter->addTypeAlias('Alias', '\Vendor\Original');
         $this->converter->removeTypeAlias('Alias');
@@ -48,10 +45,8 @@ class ComponentArgumentConverterTest extends \TYPO3\TestingFramework\Core\Unit\U
         );
     }
 
-    /**
-     * @test
-     */
-    public function resolveTypeAliasCollection()
+    #[Test]
+    public function resolveTypeAliasCollection(): void
     {
         $this->converter->addTypeAlias('Alias', '\Vendor\Original');
 
@@ -61,10 +56,8 @@ class ComponentArgumentConverterTest extends \TYPO3\TestingFramework\Core\Unit\U
         );
     }
 
-    /**
-     * @test
-     */
-    public function addRemoveConversionInterface()
+    #[Test]
+    public function addRemoveConversionInterface(): void
     {
         $this->assertEquals(
             [],
@@ -93,10 +86,8 @@ class ComponentArgumentConverterTest extends \TYPO3\TestingFramework\Core\Unit\U
         );
     }
 
-    /**
-     * @test
-     */
-    public function canTypeBeConvertedToType()
+    #[Test]
+    public function canTypeBeConvertedToType(): void
     {
         $this->converter->addConversionInterface(
             'string',
@@ -157,10 +148,8 @@ class ComponentArgumentConverterTest extends \TYPO3\TestingFramework\Core\Unit\U
         );
     }
 
-    /**
-     * @test
-     */
-    public function canTypeBeConvertedToTypeCached()
+    #[Test]
+    public function canTypeBeConvertedToTypeCached(): void
     {
         $this->converter->addConversionInterface(
             'string',
@@ -181,10 +170,8 @@ class ComponentArgumentConverterTest extends \TYPO3\TestingFramework\Core\Unit\U
         );
     }
 
-    /**
-     * @test
-     */
-    public function convertValueToSameType()
+    #[Test]
+    public function convertValueToSameType(): void
     {
         $this->assertEquals(
             'My string',
@@ -192,10 +179,8 @@ class ComponentArgumentConverterTest extends \TYPO3\TestingFramework\Core\Unit\U
         );
     }
 
-    /**
-     * @test
-     */
-    public function convertValueToUnregisteredType()
+    #[Test]
+    public function convertValueToUnregisteredType(): void
     {
         $this->assertEquals(
             'My string',
@@ -203,10 +188,8 @@ class ComponentArgumentConverterTest extends \TYPO3\TestingFramework\Core\Unit\U
         );
     }
 
-    /**
-     * @test
-     */
-    public function convertValueToType()
+    #[Test]
+    public function convertValueToType(): void
     {
         $this->converter->addConversionInterface(
             'string',
@@ -220,10 +203,8 @@ class ComponentArgumentConverterTest extends \TYPO3\TestingFramework\Core\Unit\U
         );
     }
 
-    /**
-     * @test
-     */
-    public function convertChildClassToType()
+    #[Test]
+    public function convertChildClassToType(): void
     {
         $this->converter->addConversionInterface(
             BaseObject::class,
@@ -241,10 +222,8 @@ class ComponentArgumentConverterTest extends \TYPO3\TestingFramework\Core\Unit\U
         );
     }
 
-    /**
-     * @test
-     */
-    public function convertArrayToType()
+    #[Test]
+    public function convertArrayToType(): void
     {
         $this->converter->addConversionInterface(
             'string',
@@ -262,10 +241,8 @@ class ComponentArgumentConverterTest extends \TYPO3\TestingFramework\Core\Unit\U
         $this->assertEquals('second', $converted[1]->value);
     }
 
-    /**
-     * @test
-     */
-    public function convertIteratorToType()
+    #[Test]
+    public function convertIteratorToType(): void
     {
         $this->converter->addConversionInterface(
             'string',

--- a/Tests/Unit/Utility/ComponentLoaderTest.php
+++ b/Tests/Unit/Utility/ComponentLoaderTest.php
@@ -2,10 +2,15 @@
 
 namespace SMS\FluidComponents\Tests\Unit\Utility;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Test;
 use SMS\FluidComponents\Utility\ComponentLoader;
 
 class ComponentLoaderTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
 {
+    protected ComponentLoader $loader;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -13,12 +18,12 @@ class ComponentLoaderTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
         $this->loader = new ComponentLoader();
     }
 
-    protected function getFixturePath($fixtureName)
+    protected static function getFixturePath($fixtureName)
     {
-        return realpath(dirname(__FILE__) . '/../../Fixtures/Unit/' . $fixtureName);
+        return realpath(__DIR__ . '/../../Fixtures/Unit/' . $fixtureName);
     }
 
-    public function addNamespaceProvider()
+    public static function addNamespaceProvider()
     {
         return [
             'namespaceWithLeadingTrailingBackslash' => [
@@ -38,11 +43,9 @@ class ComponentLoaderTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider addNamespaceProvider
-     */
-    public function addNamespace(string $namespace, string $path, array $namespaces)
+    #[Test]
+    #[DataProvider('addNamespaceProvider')]
+    public function addNamespace(string $namespace, string $path, array $namespaces): void
     {
         $this->loader->addNamespace($namespace, $path);
         $this->assertEquals(
@@ -51,11 +54,9 @@ class ComponentLoaderTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
         );
     }
 
-    /**
-     * @test
-     * @depends addNamespace
-     */
-    public function removeNamespace()
+    #[Depends('addNamespace')]
+    #[Test]
+    public function removeNamespace(): void
     {
         $namespace = 'Vendor\\Extension\\Category';
         $this->loader
@@ -68,7 +69,7 @@ class ComponentLoaderTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
         );
     }
 
-    public function setNamespacesProvider()
+    public static function setNamespacesProvider()
     {
         return [
             'case1' => [
@@ -94,38 +95,36 @@ class ComponentLoaderTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider setNamespacesProvider
-     */
-    public function setNamespaces(array $namespaces, array $sortedNamespaces)
+    #[Test]
+    #[DataProvider('setNamespacesProvider')]
+    public function setNamespaces(array $namespaces, array $sortedNamespaces): void
     {
         $this->loader->setNamespaces($namespaces);
         $this->assertEquals($sortedNamespaces, $this->loader->getNamespaces());
     }
 
-    public function findComponentProvider()
+    public static function findComponentProvider()
     {
         return [
             'existingComponent' => [
                 'Sitegeist\\Fixtures\\ComponentLoader\\Atom\\Button',
                 '.html',
-                $this->getFixturePath('ComponentLoader/Atom/Button/Button.html')
+                self::getFixturePath('ComponentLoader/Atom/Button/Button.html')
             ],
             'existingComponentFileExtension' => [
                 'Sitegeist\\Fixtures\\ComponentLoader\\Atom\\Button',
                 '.test',
-                $this->getFixturePath('ComponentLoader/Atom/Button/Button.test')
+                self::getFixturePath('ComponentLoader/Atom/Button/Button.test')
             ],
             'existingComponentFirstLevel' => [
                 'Sitegeist\\Fixtures\\ComponentLoader\\Example',
                 '.html',
-                $this->getFixturePath('ComponentLoader/Example/Example.html')
+                self::getFixturePath('ComponentLoader/Example/Example.html')
             ],
             'existingComponentThirdLevel' => [
                 'Sitegeist\\Fixtures\\ComponentLoader\\Molecule\\Teaser\\Headline',
                 '.html',
-                $this->getFixturePath('ComponentLoader/Molecule/Teaser/Headline/Headline.html')
+                self::getFixturePath('ComponentLoader/Molecule/Teaser/Headline/Headline.html')
             ],
             'nonexistingComponent' => [
                 'Sitegeist\\Fixtures\\ComponentLoader\\Atom\\Label',
@@ -145,16 +144,14 @@ class ComponentLoaderTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @depends addNamespace
-     * @dataProvider findComponentProvider
-     */
-    public function findComponent(string $componentIdentifier, string $fileExtension, $result)
+    #[Depends('addNamespace')]
+    #[Test]
+    #[DataProvider('findComponentProvider')]
+    public function findComponent(string $componentIdentifier, string $fileExtension, $result): void
     {
         $this->loader->addNamespace(
             'Sitegeist\\Fixtures\\ComponentLoader',
-            $this->getFixturePath('ComponentLoader')
+            self::getFixturePath('ComponentLoader')
         );
 
         // Test uncached version
@@ -170,41 +167,39 @@ class ComponentLoaderTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
         );
     }
 
-    public function findComponentsInNamespaceProvider()
+    public static function findComponentsInNamespaceProvider()
     {
         return [
             'html' => [
                 '.html',
                 [
-                    'Sitegeist\\Fixtures\\ComponentLoader\\Atom\\Button' => $this->getFixturePath('ComponentLoader/Atom/Button/Button.html'),
-                    'Sitegeist\\Fixtures\\ComponentLoader\\Atom\\ComponentLoaderSymlink' => $this->getFixturePath('ComponentLoader/Atom/ComponentLoaderSymlink/ComponentLoaderSymlink.html'),
-                    'Sitegeist\\Fixtures\\ComponentLoader\\Atom\\Link' => $this->getFixturePath('ComponentLoader/Atom/Link/Link.html'),
-                    'Sitegeist\\Fixtures\\ComponentLoader\\Example' => $this->getFixturePath('ComponentLoader/Example/Example.html'),
-                    'Sitegeist\\Fixtures\\ComponentLoader\\Molecule\\Teaser' => $this->getFixturePath('ComponentLoader/Molecule/Teaser/Teaser.html'),
-                    'Sitegeist\\Fixtures\\ComponentLoader\\Molecule\\Teaser\\Headline' => $this->getFixturePath('ComponentLoader/Molecule/Teaser/Headline/Headline.html')
+                    'Sitegeist\\Fixtures\\ComponentLoader\\Atom\\Button' => self::getFixturePath('ComponentLoader/Atom/Button/Button.html'),
+                    'Sitegeist\\Fixtures\\ComponentLoader\\Atom\\ComponentLoaderSymlink' => self::getFixturePath('ComponentLoader/Atom/ComponentLoaderSymlink/ComponentLoaderSymlink.html'),
+                    'Sitegeist\\Fixtures\\ComponentLoader\\Atom\\Link' => self::getFixturePath('ComponentLoader/Atom/Link/Link.html'),
+                    'Sitegeist\\Fixtures\\ComponentLoader\\Example' => self::getFixturePath('ComponentLoader/Example/Example.html'),
+                    'Sitegeist\\Fixtures\\ComponentLoader\\Molecule\\Teaser' => self::getFixturePath('ComponentLoader/Molecule/Teaser/Teaser.html'),
+                    'Sitegeist\\Fixtures\\ComponentLoader\\Molecule\\Teaser\\Headline' => self::getFixturePath('ComponentLoader/Molecule/Teaser/Headline/Headline.html')
                 ]
             ],
             'test' => [
                 '.test',
                 [
-                    'Sitegeist\\Fixtures\\ComponentLoader\\Atom\\Button' => $this->getFixturePath('ComponentLoader/Atom/Button/Button.test'),
-                    'Sitegeist\\Fixtures\\ComponentLoader\\Atom\\Link' => $this->getFixturePath('ComponentLoader/Atom/Link/Link.test')
+                    'Sitegeist\\Fixtures\\ComponentLoader\\Atom\\Button' => self::getFixturePath('ComponentLoader/Atom/Button/Button.test'),
+                    'Sitegeist\\Fixtures\\ComponentLoader\\Atom\\Link' => self::getFixturePath('ComponentLoader/Atom/Link/Link.test')
                 ]
             ]
         ];
     }
 
-    /**
-     * @test
-     * @depends addNamespace
-     * @dataProvider findComponentsInNamespaceProvider
-     */
-    public function findComponentsInNamespace(string $fileExtension, array $result)
+    #[Depends('addNamespace')]
+    #[Test]
+    #[DataProvider('findComponentsInNamespaceProvider')]
+    public function findComponentsInNamespace(string $fileExtension, array $result): void
     {
         $namespace = 'Sitegeist\\Fixtures\\ComponentLoader';
         $this->loader->addNamespace(
             $namespace,
-            $this->getFixturePath('ComponentLoader')
+            self::getFixturePath('ComponentLoader')
         );
 
         $this->assertEquals(
@@ -213,11 +208,9 @@ class ComponentLoaderTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
         );
     }
 
-    /**
-     * @depends addNamespace
-     * @test
-     */
-    public function findComponentsInNonexistingNamespace()
+    #[Depends('addNamespace')]
+    #[Test]
+    public function findComponentsInNonexistingNamespace(): void
     {
         $this->assertEquals(
             [],
@@ -225,16 +218,14 @@ class ComponentLoaderTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
         );
     }
 
-    /**
-     * @depends addNamespace
-     * @test
-     */
-    public function findComponentsInNonexistingNamespacePath()
+    #[Depends('addNamespace')]
+    #[Test]
+    public function findComponentsInNonexistingNamespacePath(): void
     {
         $namespace = 'Sitegeist\\Fixtures\\NonExistingPath';
         $this->loader->addNamespace(
             $namespace,
-            $this->getFixturePath('ComponentLoader') . '/NonExisting/'
+            self::getFixturePath('ComponentLoader') . '/NonExisting/'
         );
         $this->assertEquals(
             [],

--- a/Tests/Unit/Utility/ComponentPrefixer/GenericComponentPrefixerTest.php
+++ b/Tests/Unit/Utility/ComponentPrefixer/GenericComponentPrefixerTest.php
@@ -2,10 +2,13 @@
 
 namespace SMS\FluidComponents\Tests\Unit\Utility\ComponentPrefixer;
 
+use PHPUnit\Framework\Attributes\Test;
 use SMS\FluidComponents\Utility\ComponentPrefixer\GenericComponentPrefixer;
 
 class GenericComponentPrefixerTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
 {
+    protected GenericComponentPrefixer $prefixer;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -13,10 +16,8 @@ class GenericComponentPrefixerTest extends \TYPO3\TestingFramework\Core\Unit\Uni
         $this->prefixer = new GenericComponentPrefixer();
     }
 
-    /**
-     * @test
-     */
-    public function addTypeAlias()
+    #[Test]
+    public function addTypeAlias(): void
     {
         $this->assertEquals(
             'vendorAtomMycomponent',

--- a/Tests/Unit/Utility/ComponentSettingsTest.php
+++ b/Tests/Unit/Utility/ComponentSettingsTest.php
@@ -2,6 +2,7 @@
 
 namespace SMS\FluidComponents\Tests\Unit\Utility;
 
+use PHPUnit\Framework\Attributes\Test;
 use SMS\FluidComponents\Utility\ComponentSettings;
 use TYPO3\CMS\Core\TypoScript\TypoScriptService;
 
@@ -9,6 +10,7 @@ class ComponentSettingsTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCa
 {
     protected $componentSettings;
     protected $tsfe;
+    protected ComponentSettings $settings;
 
     protected function setUp(): void
     {
@@ -25,10 +27,8 @@ class ComponentSettingsTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCa
         $this->settings = new ComponentSettings(new TypoScriptService());
     }
 
-    /**
-     * @test
-     */
-    public function settingsProvidedByPhpArray()
+    #[Test]
+    public function settingsProvidedByPhpArray(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['settings'] = [
             'nested' => ['mySetting' => 'myValue'],
@@ -45,10 +45,8 @@ class ComponentSettingsTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCa
         $this->assertEquals('myValue', $this->settings['nested']['mySetting']);
     }
 
-    /**
-     * @test
-     */
-    public function settingsProvidedByPhpTypoScript()
+    #[Test]
+    public function settingsProvidedByPhpTypoScript(): void
     {
         $GLOBALS['TSFE']->tmpl->setup['config.']['tx_fluidcomponents.']['settings.'] = [
             'nested.' => ['mySetting' => 'myValue'],
@@ -67,10 +65,8 @@ class ComponentSettingsTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCa
         unset($GLOBALS['TSFE']);
     }
 
-    /**
-     * @test
-     */
-    public function settingsMergedFromPhpArrayAndTypoScript()
+    #[Test]
+    public function settingsMergedFromPhpArrayAndTypoScript(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['settings'] = [
             'nested' => ['mySetting' => 'myValue'],
@@ -95,10 +91,8 @@ class ComponentSettingsTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCa
         unset($GLOBALS['TSFE']);
     }
 
-    /**
-     * @test
-     */
-    public function settingsProvidedByApi()
+    #[Test]
+    public function settingsProvidedByApi(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluid_components']['settings'] = [
             'nested' => ['mySetting' => 'myValue'],
@@ -121,10 +115,8 @@ class ComponentSettingsTest extends \TYPO3\TestingFramework\Core\Unit\UnitTestCa
         $this->assertEquals('apiValue', $this->settings['nested']['mySetting']);
     }
 
-    /**
-     * @test
-     */
-    public function unsetSettingByApi()
+    #[Test]
+    public function unsetSettingByApi(): void
     {
         $this->settings->set('mySetting', 'myValue');
         $this->assertEquals('myValue', $this->settings->get('mySetting'));

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     },
     "require": {
         "php": "^8.2",
-        "typo3/cms-core": "^13.1 || ^12.4",
-        "typo3fluid/fluid": "^2"
+        "typo3/cms-core": "13.2.* || ^12.4",
+        "typo3fluid/fluid": "<=2.14.1"
     },
     "require-dev": {
         "typo3/testing-framework": "^8.2",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require": {
         "php": "^8.2",
-        "typo3/cms-core": "^13.1 || ^12.2",
+        "typo3/cms-core": "^13.1 || ^12.4",
         "typo3fluid/fluid": "^2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,12 @@
         "issues": "https://github.com/sitegeist/fluid-components/issues"
     },
     "require": {
-        "typo3/cms-core": "^12.2 || ^11.5",
+        "php": "^8.2",
+        "typo3/cms-core": "^13.1 || ^12.2",
         "typo3fluid/fluid": "^2"
     },
     "require-dev": {
-        "typo3/testing-framework": "^6.0 || ^7.0",
+        "typo3/testing-framework": "^8.2",
         "squizlabs/php_codesniffer": "^3.0",
         "editorconfig-checker/editorconfig-checker": "^10.0",
         "phpspec/prophecy-phpunit": "^2.0"
@@ -58,9 +59,6 @@
         }
     },
     "scripts": {
-        "post-autoload-dump": [
-            "TYPO3\\TestingFramework\\Composer\\ExtensionTestEnvironment::prepare"
-        ],
         "prepare-release": [
             "sed -i'' -e \"s/'version' => ''/'version' => '$(echo ${GITHUB_REF#refs/tags/} | sed 's/v//')'/\" ext_emconf.php",
             "rm -r .github .ecrc .editorconfig .gitattributes Build Tests"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -7,13 +7,11 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => 'mathes@sitegeist.de, moin@praetorius.me',
     'author_company' => 'sitegeist media solutions GmbH',
     'state' => 'stable',
-    'uploadfolder' => false,
-    'clearCacheOnLoad' => false,
     'version' => '',
     'constraints' => [
         'depends' => [
-            'typo3' => '11.5.0-12.9.99',
-            'php' => '7.4.0-8.9.99'
+            'typo3' => '12.4.0-13.4.99',
+            'php' => '8.2.0-8.2.99'
         ],
         'conflicts' => [
         ],

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -10,8 +10,8 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '',
     'constraints' => [
         'depends' => [
-            'typo3' => '12.4.0-13.4.99',
-            'php' => '8.2.0-8.2.99'
+            'typo3' => '12.4.0-13.9.99',
+            'php' => '8.2.0-8.3.99'
         ],
         'conflicts' => [
         ],


### PR DESCRIPTION
I'm not sure about [[v13] translate without alternativeLanguageKeys](https://github.com/sitegeist/fluid-components/commit/6dd1ec617b278b75115bcda938cd453f388e6687) as it seems we could get rid of the `alternativeLanguageKeys` as the core does. But this would have a higher impact and would need preparation beforehand. 

I marked the ViewHelper Arguments as deprecated and in doing so preparing for the next major release? We planned to give the extension a fresh-up within this year. So that could be a better case to get rid of this parameter.