### PR TITLE
[BUGFIX] fetch ServerRequest v12 compatible

### DIFF
--- a/Classes/ViewHelpers/Form/TranslatedValidationResultsViewHelper.php
+++ b/Classes/ViewHelpers/Form/TranslatedValidationResultsViewHelper.php
@@ -281,7 +281,7 @@ class TranslatedValidationResultsViewHelper extends AbstractViewHelper
         );
     }
 
-    private function getRequest(): RequestInterface
+    private function getRequest():? RequestInterface
     {
         if (method_exists($this->renderingContext, 'getAttribute') &&
             method_exists($this->renderingContext, 'hasAttribute') &&

--- a/Classes/ViewHelpers/Translate/LabelsViewHelper.php
+++ b/Classes/ViewHelpers/Translate/LabelsViewHelper.php
@@ -68,7 +68,7 @@ class LabelsViewHelper extends AbstractViewHelper
         return $labels;
     }
 
-    private function getRequest(): RequestInterface
+    private function getRequest():? RequestInterface
     {
         if (method_exists($this->renderingContext, 'getAttribute') &&
             method_exists($this->renderingContext, 'hasAttribute') &&

--- a/Tests/Functional/ComponentRendererTest.php
+++ b/Tests/Functional/ComponentRendererTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\Test;
 use SMS\FluidComponents\Fluid\ViewHelper\ComponentRenderer;
 use TYPO3\CMS\Core\Cache\Backend\NullBackend;
 use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
 use TYPO3\CMS\Extbase\Mvc\Request;
@@ -79,15 +80,25 @@ class ComponentRendererTest extends FunctionalTestCase
         /** @var ViewHelperInvoker $invoker */
         $invoker = GeneralUtility::makeInstance(ViewHelperInvoker::class);
 
-        $renderingContext = $container->get(RenderingContextFactory::class)->create(
-            [],
-            new Request(
+        if (GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion() < 13) {
+            $renderingContext = GeneralUtility::makeInstance(RenderingContextFactory::class)->create();
+            $renderingContext->setRequest(new Request(
                 (new ServerRequest)->withAttribute(
                     'extbase',
                     new ExtbaseRequestParameters
                 )
-            )
-        );
+            ));
+        } else {
+            $renderingContext = GeneralUtility::makeInstance(RenderingContextFactory::class)->create(
+                [],
+                new Request(
+                    (new ServerRequest)->withAttribute(
+                        'extbase',
+                        new ExtbaseRequestParameters
+                    )
+                )
+            );
+        }
 
         $output = $invoker->invoke(
             $renderer,

--- a/Tests/Functional/ParameterEscapingTest.php
+++ b/Tests/Functional/ParameterEscapingTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use SMS\FluidComponents\Utility\ComponentLoader;
 use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
 use TYPO3\CMS\Extbase\Mvc\Request;
@@ -196,17 +197,28 @@ class ParameterEscapingTest extends FunctionalTestCase
     public function render(string $template, string $expected): void
     {
         $view = new TemplateView();
-        $view->setRenderingContext(
-            GeneralUtility::makeInstance(RenderingContextFactory::class)->create(
-                [],
-                new Request(
-                    (new ServerRequest)->withAttribute(
-                        'extbase',
-                        new ExtbaseRequestParameters
+        if (GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion() < 13) {
+            $renderingContext = GeneralUtility::makeInstance(RenderingContextFactory::class)->create();
+            $renderingContext->setRequest(new Request(
+                (new ServerRequest)->withAttribute(
+                    'extbase',
+                    new ExtbaseRequestParameters
+                )
+            ));
+            $view->setRenderingContext($renderingContext);
+        } else {
+            $view->setRenderingContext(
+                GeneralUtility::makeInstance(RenderingContextFactory::class)->create(
+                    [],
+                    new Request(
+                        (new ServerRequest)->withAttribute(
+                            'extbase',
+                            new ExtbaseRequestParameters
+                        )
                     )
                 )
-            )
-        );
+            );
+        }
 
         $view->getRenderingContext()->getViewHelperResolver()->addNamespace('fc', 'SMS\\FluidComponents\\ViewHelpers');
         $view->getRenderingContext()->getViewHelperResolver()->addNamespace('test', 'SMS\\FluidComponents\\Tests\\Fixtures\\Functional\\Components');


### PR DESCRIPTION
add v12 and v13 compatible versions for fetching Server Request Deprecation: #104684 - Fluid RenderingContext->getRequest()

Testing Context:
RenderingContextFactory does not accept ServerRequest in create(). We have to setRequest() afterwards.