### PR TITLE
[FEATURE] generate placeholder images internal

### DIFF
--- a/Classes/Domain/Model/PlaceholderImage.php
+++ b/Classes/Domain/Model/PlaceholderImage.php
@@ -4,7 +4,9 @@ namespace SMS\FluidComponents\Domain\Model;
 
 use SMS\FluidComponents\Interfaces\ImageWithDimensions;
 use SMS\FluidComponents\Interfaces\ProcessableImage;
+use SMS\FluidComponents\Service\PlaceholderImageService;
 use TYPO3\CMS\Core\Imaging\ImageManipulation\Area;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Data structure for a placeholder image to be passed to a component.
@@ -29,16 +31,16 @@ class PlaceholderImage extends Image implements ImageWithDimensions, Processable
     /**
      * Image format of the image
      */
-    protected string $format = 'gif';
+    protected string $format = 'svg';
 
     /**
      * Creates an image object for a placeholder image.
      */
-    public function __construct(int $width, int $height, string $format = 'gif')
+    public function __construct(int $width, int $height, ?string $format = null)
     {
         $this->width = $width;
         $this->height = $height;
-        $this->format = $format;
+        $this->format = $format ?? $this->format;
     }
 
     public function getWidth(): int
@@ -58,7 +60,11 @@ class PlaceholderImage extends Image implements ImageWithDimensions, Processable
 
     public function getPublicUrl(): string
     {
-        return 'https://via.placeholder.com/' . $this->width . 'x' . $this->height . '.' . $this->format;
+        return GeneralUtility::makeInstance(PlaceholderImageService::class)->generate(
+            $this->width,
+            $this->height,
+            $this->format,
+        );
     }
 
     public function process(int $width, int $height, ?string $format, Area $cropArea): ProcessableImage

--- a/Classes/Service/PlaceholderImageService.php
+++ b/Classes/Service/PlaceholderImageService.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types=1);
+
+namespace SMS\FluidComponents\Service;
+
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\View\ViewFactoryData;
+use TYPO3\CMS\Core\View\ViewFactoryInterface;
+use TYPO3\CMS\Fluid\View\StandaloneView;
+use TYPO3\CMS\Frontend\Imaging\GifBuilder;
+
+class PlaceholderImageService
+{
+    const int STROKE_WIDTH = 18;
+    const int STROKE_HEIGHT = 3;
+    const string BACKGROUND_COLOR = '#C0C0C0';
+    const string COLOR = '#0B0B13';
+
+    public function __construct(
+        private readonly GifBuilder $gifBuilder,
+        private readonly ?ViewFactoryInterface $viewFactory = null,
+    ) {
+    }
+
+    public function generate(int $width, int $height, string $format): string
+    {
+        $text = sprintf('%dx%d.%s', $width, $height, $format);
+        if ($format !== 'svg') {
+            return $this->generateBitmap($width, $height, $format, $text);
+        }
+
+        if (GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion() < 13) {
+            $view = new StandaloneView();
+            $view->setTemplatePathAndFilename('EXT:fluid_components/Resources/Private/Templates/Placeholder.svg');
+        } else {
+            $view = $this->viewFactory->create(new ViewFactoryData(
+                templatePathAndFilename: 'EXT:fluid_components/Resources/Private/Templates/Placeholder.svg',
+            ));
+        }
+
+        $view->assignMultiple([
+            'width' => $width,
+            'height' => $height,
+            'backgroundColor' => self::BACKGROUND_COLOR,
+            'color' => self::COLOR,
+            'text' => $text,
+        ]);
+        return 'data:image/svg+xml;base64,' . base64_encode($view->render());
+    }
+
+    private function generateBitmap(int $width, int $height, string $format, string $text): string
+    {
+        $configuration = [
+            'XY' => implode(',', [$width, $height]),
+                'backColor' => self::BACKGROUND_COLOR,
+                'format' => $format,
+                '10' => 'TEXT',
+                '10.' => [
+                    'text' => $text,
+                    'fontColor' => self::COLOR,
+                    'fontSize' => round($width / 9),
+                    'align' => 'center',
+                    'offset' => implode(',', [0, $height / 1.75]),
+                ],
+        ];
+
+        $strokes = [
+            [0 ,0 , self::STROKE_WIDTH, self::STROKE_HEIGHT],
+            [0 ,0 , self::STROKE_HEIGHT, self::STROKE_WIDTH],
+            [($width - self::STROKE_WIDTH), 0, $width , self::STROKE_HEIGHT],
+            [($width - self::STROKE_HEIGHT), 0, $width,  self::STROKE_WIDTH],
+            [0, ($height - self::STROKE_HEIGHT), self::STROKE_WIDTH, $height],
+            [0, ($height - self::STROKE_WIDTH), self::STROKE_HEIGHT, $height],
+            [($width - self::STROKE_WIDTH), ($height - self::STROKE_HEIGHT), $width, $height],
+            [($width - self::STROKE_HEIGHT), ($height - self::STROKE_WIDTH), $width, $height],
+        ];
+
+        foreach ($strokes as $key => $dimensions) {
+            $configuration[10 * ($key + 2)] = 'BOX';
+            $configuration[10 * ($key + 2) . '.'] = [
+                'dimensions' => implode(',', $dimensions),
+                'color' => self::COLOR,
+            ];
+        }
+
+        $this->gifBuilder->start($configuration, []);
+
+        if (GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion() < 13 && is_string($imagePath = $this->gifBuilder->gifBuild())) {
+            return $imagePath;
+        }
+        return (string) $this->gifBuilder->gifBuild()->getPublicUrl();
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -8,6 +8,9 @@ services:
         resource: '../Classes/*'
         exclude: '../Classes/Domain/Model/*'
 
+    SMS\FluidComponents\Service\PlaceholderImageService:
+        public: true
+
     SMS\FluidComponents\Command\GenerateXsdCommand:
         tags:
             -   name: 'console.command'

--- a/Resources/Private/Templates/Placeholder.svg
+++ b/Resources/Private/Templates/Placeholder.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">
+    <style>
+        rect { fill:{backgroundColor}; width: 100%; height: 100%; }
+        foreignObject { width: 100%; height: 100%; }
+        div { container-type: inline-size; position: absolute; top: 0; right: 0; bottom: 0; left: 0; }
+        p { color: {color}; font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace; font-size: {width/9}px; position: absolute; left: 0; width: 100%; text-align: center; transform: translateY(-100%); top: 50%; }
+        .corner { border-color: {color}; border-style: solid; border-width: 3px; display: block; position: absolute; width: 15px; height: 15px; }
+        .corner-tl { border-bottom: none; border-right: none; left: 0; top: 0; }
+        .corner-tr { border-bottom: none; border-left: none; top: 0; right: 0; }
+        .corner-bl { border-right: none; border-top: none; bottom: 0; left: 0; }
+        .corner-br { border-left: none; border-top: none; bottom: 0; right: 0; }
+    </style>
+    <rect width="10" height="10" x="0" y="0" />
+    <foreignObject x="0" y="0" width="{width}" height="{height}">
+        <div xmlns="http://www.w3.org/1999/xhtml">
+            <p>{text}</p>
+            <span class="corner corner-tl"></span>
+            <span class="corner corner-tr"></span>
+            <span class="corner corner-bl"></span>
+            <span class="corner corner-br"></span>
+        </div>
+    </foreignObject>
+</svg>

--- a/Tests/Functional/PlaceholderImageServiceTest.php
+++ b/Tests/Functional/PlaceholderImageServiceTest.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace SMS\FluidComponents\Tests\Functional\Service;
+
+use SMS\FluidComponents\Service\PlaceholderImageService;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Imaging\GifBuilder;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+class PlaceholderImageServiceTest extends FunctionalTestCase
+{
+    protected bool $initializeDatabase = false;
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/fluid_components',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function testGenerateBitmap(): void
+    {
+        $gifBuilder = GeneralUtility::makeInstance(GifBuilder::class);
+        $service = new PlaceholderImageService($gifBuilder);
+
+        $result = $service->generate(100, 50, 'png');
+        $this->assertStringContainsString('100x50.png_', $result);
+        $this->assertStringEndsWith('.png', $result);
+    }
+
+    public function testGenerateSvg(): void
+    {
+        $gifBuilder = GeneralUtility::makeInstance(GifBuilder::class);
+
+        if (GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion() < 13) {
+            $viewFactory = null;
+        } else {
+            $viewFactory = $this->createMock(\TYPO3\CMS\Core\View\ViewFactoryInterface::class);
+            $view = $this->createMock(\TYPO3\CMS\Core\View\ViewInterface::class);
+            $view->method('render')->willReturn('<svg></svg>');
+            $viewFactory->method('create')->willReturn($view);
+            GeneralUtility::addInstance(\TYPO3\CMS\Core\View\ViewFactoryInterface::class, $viewFactory);
+        }
+
+        $service = new PlaceholderImageService($gifBuilder, $viewFactory);
+
+        $result = $service->generate(100, 50, 'svg');
+        $this->assertStringStartsWith('data:image/svg+xml;base64,', $result);
+        $this->assertStringEndsNotWith('data:image/svg+xml;base64,', $result);
+    }
+
+}


### PR DESCRIPTION
I used #119 as a starting point and added a SVG which is used inline as image `src`. The placeholder images now uses svg as standard as it does not uses disk space for generated pixel images.

Thanks [sascha-egerer](https://github.com/sascha-egerer) for the GifBuilder part and Ralf for the SVG file.