### PR TITLE
[BUGFIX] Clarify exception for missing ViewHelper

### DIFF
--- a/Classes/Fluid/ViewHelper/ComponentResolver.php
+++ b/Classes/Fluid/ViewHelper/ComponentResolver.php
@@ -91,8 +91,8 @@ class ComponentResolver extends ViewHelperResolver
             $resolvedViewHelperClassName = $this->resolveViewHelperName($namespaceIdentifier, $methodIdentifier);
             $actualViewHelperClassName = $this->generateViewHelperClassName($resolvedViewHelperClassName);
             if (false === class_exists($actualViewHelperClassName) || $actualViewHelperClassName == '') {
-                $resolvedViewHelperClassName = $this->resolveComponentName($namespaceIdentifier, $methodIdentifier);
-                $actualViewHelperClassName = $this->generateViewHelperClassName($resolvedViewHelperClassName);
+                $resolvedComponentName = $this->resolveComponentName($namespaceIdentifier, $methodIdentifier);
+                $actualViewHelperClassName = $this->generateViewHelperClassName($resolvedComponentName);
 
                 $componentLoader = $this->getComponentLoader();
                 $componentFile = $componentLoader->findComponent($actualViewHelperClassName);


### PR DESCRIPTION
Currently, the exception message for a missing ViewHelper includes the "fake component namespace" without the ViewHelper suffix. This makes the exception hard to understand, since the problem is probably not related to a missing component but to a missing ViewHelper.

before:

> The ViewHelper "<vac:asset.vite>" could not be resolved. Based on your spelling, the system would load the class "Praetorius\ViteAssetCollector\ViewHelpers\Asset\Vite", however this class does not exist. 

after:

> The ViewHelper "<vac:asset.vite>" could not be resolved. Based on your spelling, the system would load the class "Praetorius\ViteAssetCollector\ViewHelpers\Asset\ViteViewHelper", however this class does not exist.