### PR TITLE
[BUGFIX] Use nullable return type for fromString() of ConstructibleFromString

### DIFF
--- a/Classes/Interfaces/ConstructibleFromString.php
+++ b/Classes/Interfaces/ConstructibleFromString.php
@@ -10,11 +10,7 @@ namespace SMS\FluidComponents\Interfaces;
 interface ConstructibleFromString
 {
     /**
-     * Creates an instance of the class based on the provided string.
-     *
-     * @param string $value
-     *
-     * @return object
+     * Creates an instance of the class based on the provided string
      */
-    public static function fromString(string $value);
+    public static function fromString(string $value): ?object;
 }


### PR DESCRIPTION
As already used throughout the codebase, the return-type of the `fromString()` method inside `ConstructibleFromString`-Interface has been adjusted to additionally allow null.