### PR TITLE
Add compatibility with fluid 4.2

### DIFF
--- a/Classes/Fluid/ViewHelper/ComponentResolver.php
+++ b/Classes/Fluid/ViewHelper/ComponentResolver.php
@@ -130,7 +130,7 @@ class ComponentResolver extends ViewHelperResolver
         }
 
         $componentLoader = $this->getComponentLoader();
-        $namespaces = (array) $this->namespaces[$namespaceIdentifier];
+        $namespaces = (array) $this->getNamespaces()[$namespaceIdentifier];
 
         do {
             $name = rtrim((string) array_pop($namespaces), '\\') . '\\' . $className;


### PR DESCRIPTION
In fluid, 4.2.0 the variable `$localNamespaces` was introduced. The components are now registered in `$localNamespaces` and not in `$namespaces` anymore.

The method `getNamespaces()` returns all of them and is also backwards compatible to 4.1.x